### PR TITLE
add findAll queries for ADOP and ChainConfigs

### DIFF
--- a/src/ado-package/ado-package.resolver.ts
+++ b/src/ado-package/ado-package.resolver.ts
@@ -1,13 +1,23 @@
-import { Args, Query, Resolver } from '@nestjs/graphql'
+import { Args, Query, ResolveField, Resolver } from '@nestjs/graphql'
 import { AdoPackageService } from './ado-package.service'
-import { AdoPackage, ADOPArgs } from './types'
+import { AdoPackage, ADOPArgs, ADOPQuery } from './types'
 
-@Resolver(AdoPackage)
+@Resolver(ADOPQuery)
 export class AdoPackageResolver {
   constructor(private readonly adoPackageService: AdoPackageService) {}
 
-  @Query(() => AdoPackage)
-  public async ADOP(@Args() args: ADOPArgs): Promise<AdoPackage> {
+  @Query(() => ADOPQuery)
+  public async ADOP(): Promise<ADOPQuery> {
+    return {} as ADOPQuery
+  }
+
+  @ResolveField(() => [String])
+  public async adoTypes(): Promise<string[]> {
+    return this.adoPackageService.getAdoTypes()
+  }
+
+  @ResolveField(() => AdoPackage)
+  public async package(@Args() args: ADOPArgs): Promise<AdoPackage> {
     return this.adoPackageService.getPackage(args.adoType)
   }
 }

--- a/src/ado-package/ado-package.service.ts
+++ b/src/ado-package/ado-package.service.ts
@@ -4,7 +4,7 @@ import { ApolloError, UserInputError } from 'apollo-server'
 import { Model } from 'mongoose'
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
 import { AdoType, DEFAULT_CATCH_ERR, MONGO_QUERY_ERROR } from 'src/ado/types'
-import { AdoPackage, NOT_FOUND_ERR } from './types'
+import { AdoPackage, ADO_TYPES_NOT_FOUND_ERR, ADO_TYPE_NOT_FOUND_ERR } from './types'
 
 @Injectable()
 export class AdoPackageService {
@@ -15,10 +15,26 @@ export class AdoPackageService {
     private adoPackageModel?: Model<AdoPackage>,
   ) {}
 
+  public async getAdoTypes(): Promise<string[]> {
+    try {
+      const packages = await this.adoPackageModel?.find({}, { name: 1, _id: 0 })
+      if (!packages || !packages.length) throw new UserInputError(ADO_TYPES_NOT_FOUND_ERR)
+
+      return packages.map((p) => p.name)
+    } catch (err: any) {
+      this.logger.error({ err }, DEFAULT_CATCH_ERR)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(MONGO_QUERY_ERROR)
+    }
+  }
+
   public async getPackage(adoType: AdoType): Promise<AdoPackage> {
     try {
       const adoPackage = await this.adoPackageModel?.findOne({ name: adoType })
-      if (!adoPackage) throw new UserInputError(NOT_FOUND_ERR)
+      if (!adoPackage) throw new UserInputError(ADO_TYPE_NOT_FOUND_ERR)
 
       return adoPackage
     } catch (err: any) {

--- a/src/ado-package/types/ado-package.constants.ts
+++ b/src/ado-package/types/ado-package.constants.ts
@@ -1,1 +1,2 @@
-export const NOT_FOUND_ERR = 'unknown adoType or ado package not found'
+export const ADO_TYPE_NOT_FOUND_ERR = 'unknown adoType or ado package not found'
+export const ADO_TYPES_NOT_FOUND_ERR = 'unable to fetch ado types or none found'

--- a/src/ado-package/types/ado-package.query.ts
+++ b/src/ado-package/types/ado-package.query.ts
@@ -1,0 +1,18 @@
+import { ArgsType, Field, ObjectType } from '@nestjs/graphql'
+import { AdoType } from 'src/ado/types'
+import { AdoPackage } from './ado-package.schema'
+
+@ObjectType()
+export class ADOPQuery {
+  @Field(() => [String])
+  adoTypes!: Promise<string[]>
+
+  @Field(() => AdoPackage)
+  package!: Promise<AdoPackage>
+}
+
+@ArgsType()
+export class ADOPArgs {
+  @Field(() => AdoType)
+  adoType!: AdoType
+}

--- a/src/ado-package/types/ado-package.schema.ts
+++ b/src/ado-package/types/ado-package.schema.ts
@@ -1,13 +1,15 @@
-import { ArgsType, Field, ObjectType } from '@nestjs/graphql'
+import { Field, ObjectType } from '@nestjs/graphql'
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose'
-import { AdoType } from 'src/ado/types'
 
 export type AdoPackageDocument = AdoPackage & Document
 
 @ObjectType()
 export class ADOPSchemaReceive {
-  @Field()
-  cw721!: string
+  @Field({ nullable: true })
+  cw721?: string
+
+  @Field({ nullable: true })
+  cw20?: string
 }
 
 @ObjectType()
@@ -24,13 +26,6 @@ export class ADOPSchema {
   @Field(() => ADOPSchemaReceive, { nullable: true })
   receive?: ADOPSchemaReceive
 }
-
-@ArgsType()
-export class ADOPArgs {
-  @Field(() => AdoType)
-  adoType!: AdoType
-}
-
 @Schema()
 @ObjectType()
 export class AdoPackage {

--- a/src/ado-package/types/index.ts
+++ b/src/ado-package/types/index.ts
@@ -1,2 +1,3 @@
-export { AdoPackage, ADOPSchema, ADOPSchemaReceive, ADOPArgs } from './ado-package.schema'
-export { NOT_FOUND_ERR } from './ado-package.constants'
+export { AdoPackage, ADOPSchema, ADOPSchemaReceive } from './ado-package.schema'
+export { ADOPQuery, ADOPArgs } from './ado-package.query'
+export { ADO_TYPE_NOT_FOUND_ERR, ADO_TYPES_NOT_FOUND_ERR } from './ado-package.constants'

--- a/src/chain-config/chain-config.resolver.ts
+++ b/src/chain-config/chain-config.resolver.ts
@@ -1,13 +1,23 @@
-import { Args, Query, Resolver } from '@nestjs/graphql'
+import { Args, Query, ResolveField, Resolver } from '@nestjs/graphql'
 import { ChainConfigService } from './chain-config.service'
-import { ChainConfig } from './types'
+import { ChainConfig, ChainConfigQuery } from './types'
 
-@Resolver(ChainConfig)
+@Resolver(ChainConfigQuery)
 export class ChainConfigResolver {
   constructor(private readonly chainConfigService: ChainConfigService) {}
 
-  @Query(() => ChainConfig)
-  public async chainConfig(@Args('identifier') identifier: string) {
+  @Query(() => ChainConfigQuery)
+  public async chainConfigs(): Promise<ChainConfigQuery> {
+    return {} as ChainConfigQuery
+  }
+
+  @ResolveField(() => [ChainConfig])
+  public async allConfigs(): Promise<ChainConfig[]> {
+    return this.chainConfigService.getAllConfigs()
+  }
+
+  @ResolveField(() => ChainConfig)
+  public async config(@Args('identifier') identifier: string): Promise<ChainConfig> {
     return this.chainConfigService.getConfig(identifier)
   }
 }

--- a/src/chain-config/chain-config.service.ts
+++ b/src/chain-config/chain-config.service.ts
@@ -4,7 +4,7 @@ import { ApolloError, UserInputError } from 'apollo-server'
 import { Model } from 'mongoose'
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
 import { DEFAULT_CATCH_ERR, MONGO_QUERY_ERROR } from 'src/ado/types'
-import { ChainConfig, NOT_FOUND_ERR } from './types'
+import { ChainConfig, CHAIN_CONFIGS_NOT_FOUND_ERR, CHAIN_CONFIG_NOT_FOUND_ERR } from './types'
 
 @Injectable()
 export class ChainConfigService {
@@ -15,10 +15,26 @@ export class ChainConfigService {
     private chainConfigModel?: Model<ChainConfig>,
   ) {}
 
+  public async getAllConfigs(): Promise<ChainConfig[]> {
+    try {
+      const chainConfigs = await this.chainConfigModel?.find()
+      if (!chainConfigs || !chainConfigs.length) throw new UserInputError(CHAIN_CONFIGS_NOT_FOUND_ERR)
+
+      return chainConfigs
+    } catch (err: any) {
+      this.logger.error({ err }, DEFAULT_CATCH_ERR)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(MONGO_QUERY_ERROR)
+    }
+  }
+
   public async getConfig(identifier: string): Promise<ChainConfig> {
     try {
       const chainConfig = await this.chainConfigModel?.findOne({ $or: [{ chainId: identifier }, { name: identifier }] })
-      if (!chainConfig) throw new UserInputError(NOT_FOUND_ERR)
+      if (!chainConfig) throw new UserInputError(CHAIN_CONFIG_NOT_FOUND_ERR)
 
       return chainConfig
     } catch (err: any) {

--- a/src/chain-config/types/chain-config.constants.ts
+++ b/src/chain-config/types/chain-config.constants.ts
@@ -1,1 +1,2 @@
-export const NOT_FOUND_ERR = 'unknown identifier or chain config not found'
+export const CHAIN_CONFIG_NOT_FOUND_ERR = 'unknown identifier or chain config not found'
+export const CHAIN_CONFIGS_NOT_FOUND_ERR = 'unable to fetch chain configs or none found'

--- a/src/chain-config/types/chain-config.query.ts
+++ b/src/chain-config/types/chain-config.query.ts
@@ -1,0 +1,11 @@
+import { Field, ObjectType } from '@nestjs/graphql'
+import { ChainConfig } from './chain-config.schema'
+
+@ObjectType()
+export class ChainConfigQuery {
+  @Field(() => [ChainConfig])
+  allConfigs!: Promise<ChainConfig[]>
+
+  @Field(() => ChainConfig)
+  config!: Promise<ChainConfig>
+}

--- a/src/chain-config/types/index.ts
+++ b/src/chain-config/types/index.ts
@@ -1,2 +1,3 @@
 export { ChainConfig } from './chain-config.schema'
-export { NOT_FOUND_ERR } from './chain-config.constants'
+export { ChainConfigQuery } from './chain-config.query'
+export { CHAIN_CONFIG_NOT_FOUND_ERR, CHAIN_CONFIGS_NOT_FOUND_ERR } from './chain-config.constants'

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -2,6 +2,11 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
 
+type ADOPQuery {
+  adoTypes: [String!]!
+  package(adoType: AdoType!): AdoPackage!
+}
+
 type ADOPSchema {
   execute: String!
   instantiate: String!
@@ -10,7 +15,8 @@ type ADOPSchema {
 }
 
 type ADOPSchemaReceive {
-  cw721: String!
+  cw20: String
+  cw721: String
 }
 
 type ADORate {
@@ -308,6 +314,11 @@ type ChainConfig {
   registryAddress: String!
 }
 
+type ChainConfigQuery {
+  allConfigs: [ChainConfig!]!
+  config(identifier: String!): ChainConfig!
+}
+
 type Coin {
   amount: String!
   denom: String!
@@ -434,13 +445,13 @@ type PrimitiveResponse {
 }
 
 type Query {
-  ADOP(adoType: AdoType!): AdoPackage!
+  ADOP: ADOPQuery!
   addresslist(address: String!): AddresslistContract!
   ado(address: String!): AdoContract!
   app(address: String!): AppContract!
   assets(adoType: AdoType, limit: Int = 10, offset: Int = 0, walletAddress: String!): [AssetResult!]!
   auction(address: String!): AuctionContract!
-  chainConfig(identifier: String!): ChainConfig!
+  chainConfigs: ChainConfigQuery!
   crowdfund(address: String!): CrowdfundContract!
   cw20(address: String!): CW20Contract!
   cw721(address: String!): CW721Contract!


### PR DESCRIPTION
Additional queries to fetch all ADOPs and all ChainConfigs

**ADOPQuery**

```
query {
  ADOP {
    adoTypes
    package(adoType: App) {
      name
      schemas {
        execute
        instantiate
        query
        receive {
          cw721
        }
      }
    }
  }
}
```

**ChainConfigs Query**

```
query {
  chainConfigs {
    allConfigs {
      ...chainInfo
    }
    config(identifier: "uni-5") {
     	...chainInfo
    }
  }
}

fragment chainInfo on ChainConfig {
  name
  chainId
  chainUrl
  chainName
  chainType
  addressPrefix
  registryAddress
  blockExplorerAddressPages
  blockExplorerTxPages
  defaultFee
  iconUrls {
    sm
    lg
  }
}
```