### PR TITLE
Usecase4 ADOs

### DIFF
--- a/src/ado/ado.resolver.ts
+++ b/src/ado/ado.resolver.ts
@@ -6,6 +6,8 @@ import { AppAdo } from './app/types'
 import { AuctionAdo } from './auction/types'
 import { CrowdfundAdo } from './crowdfund/types'
 import { CW20Ado } from './cw20/types'
+import { CW20ExchangeAdo } from './cw20exchange/types'
+import { CW20StakingAdo } from './cw20staking/types'
 import { CW721Ado } from './cw721/types'
 import { FactoryAdo } from './factory/types'
 import { MarketplaceAdo } from './marketplace/types'
@@ -54,6 +56,16 @@ export class AdoResolver {
   @ResolveField(() => CW20Ado)
   public async cw20(@Args('address') address: string): Promise<CW20Ado> {
     return this.adoService.getAdo<CW20Ado>(address, AdoType.CW20)
+  }
+
+  @ResolveField(() => CW20StakingAdo)
+  public async cw20_staking(@Args('address') address: string): Promise<CW20StakingAdo> {
+    return this.adoService.getAdo<CW20StakingAdo>(address, AdoType.CW20Staking)
+  }
+
+  @ResolveField(() => CW20ExchangeAdo)
+  public async cw20_exchange(@Args('address') address: string): Promise<CW20ExchangeAdo> {
+    return this.adoService.getAdo<CW20ExchangeAdo>(address, AdoType.CW20Exchange)
   }
 
   @ResolveField(() => CW721Ado)

--- a/src/ado/cw20/cw20.resolver.ts
+++ b/src/ado/cw20/cw20.resolver.ts
@@ -1,13 +1,70 @@
-import { Parent, ResolveField, Resolver } from '@nestjs/graphql'
+import { Args, Float, Parent, ResolveField, Resolver } from '@nestjs/graphql'
+import { AndrSearchOptions } from '../types'
 import { CW20Service } from './cw20.service'
-import { CW20Ado, TokenInfo } from './types'
+import { CW20Ado, Minter, TokenInfo } from './types'
+import { Allowance, DownloadLogo, MarketingInfo } from './types/cw20.query'
 
 @Resolver(CW20Ado)
 export class CW20Resolver {
   constructor(private readonly cw20Service: CW20Service) {}
 
+  @ResolveField(() => Float)
+  public async balance(@Parent() token: CW20Ado, @Args('address') address: string): Promise<number> {
+    return this.cw20Service.balance(token.address, address)
+  }
+
   @ResolveField(() => TokenInfo)
   public async tokenInfo(@Parent() token: CW20Ado): Promise<TokenInfo> {
     return this.cw20Service.tokenInfo(token.address)
+  }
+
+  @ResolveField(() => Minter)
+  public async minter(@Parent() token: CW20Ado): Promise<Minter> {
+    return this.cw20Service.minter(token.address)
+  }
+
+  @ResolveField(() => Allowance)
+  public async allowance(
+    @Parent() token: CW20Ado,
+    @Args('owner') owner: string,
+    @Args('spender') spender: string,
+  ): Promise<Allowance> {
+    return this.cw20Service.allowance(token.address, owner, spender)
+  }
+
+  @ResolveField(() => [Allowance])
+  public async allAllowances(
+    @Parent() token: CW20Ado,
+    @Args('owner') owner: string,
+    @Args('options', { nullable: true }) options: AndrSearchOptions,
+  ): Promise<Allowance[]> {
+    return this.cw20Service.allAllowances(token.address, owner, options)
+  }
+
+  @ResolveField(() => [Allowance])
+  public async allSpenderAllowances(
+    @Parent() token: CW20Ado,
+    @Args('spender') spender: string,
+    @Args('options', { nullable: true }) options: AndrSearchOptions,
+  ): Promise<Allowance[]> {
+    return this.cw20Service.allSpenderAllowances(token.address, spender, options)
+  }
+
+  @ResolveField(() => [String])
+  public async allAccounts(
+    @Parent() token: CW20Ado,
+    @Args('options', { nullable: true }) options: AndrSearchOptions,
+  ): Promise<string[]> {
+    return this.cw20Service.allAccounts(token.address, options)
+  }
+
+  @ResolveField(() => MarketingInfo)
+  public async marketingInfo(@Parent() token: CW20Ado): Promise<MarketingInfo> {
+    return this.cw20Service.marketingInfo(token.address)
+  }
+
+  @ResolveField(() => DownloadLogo)
+  public async downloadLogo(@Parent() token: CW20Ado): Promise<DownloadLogo> {
+    return this.cw20Service.downloadLogo(token.address)
   }
 }

--- a/src/ado/cw20/cw20.service.ts
+++ b/src/ado/cw20/cw20.service.ts
@@ -3,8 +3,17 @@ import { ApolloError, UserInputError } from 'apollo-server'
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
 import { WasmService } from 'src/wasm/wasm.service'
 import { AdoService } from '../ado.service'
+import { AndrSearchOptions } from '../types'
 import { INVALID_QUERY_ERR } from '../types/ado.constants'
-import { CW20Schema, TokenInfo } from './types'
+import {
+  CW20Schema,
+  TokenInfo,
+  CW20_BALANCE_ADDRESS,
+  Minter,
+  CW20_ALLOWANCE_OWNER,
+  CW20_ALLOWANCE_SPENDER,
+} from './types'
+import { Allowance, DownloadLogo, MarketingInfo } from './types/cw20.query'
 
 @Injectable()
 export class CW20Service extends AdoService {
@@ -17,10 +26,166 @@ export class CW20Service extends AdoService {
     super(logger, wasmService)
   }
 
+  public async balance(contractAddress: string, address: string): Promise<number> {
+    try {
+      const queryMsgStr = JSON.stringify(CW20Schema.balance).replace(CW20_BALANCE_ADDRESS, address)
+      const queryMsg = JSON.parse(queryMsgStr)
+
+      const balance = await this.wasmService.queryContract(contractAddress, queryMsg)
+
+      return (balance.balance ?? 0) as number
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
   public async tokenInfo(contractAddress: string): Promise<TokenInfo> {
     try {
       const tokenInfo = await this.wasmService.queryContract(contractAddress, CW20Schema.token_info)
+
       return tokenInfo as TokenInfo
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async minter(contractAddress: string): Promise<Minter> {
+    try {
+      const minter = await this.wasmService.queryContract(contractAddress, CW20Schema.minter)
+
+      return minter as Minter
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async allowance(contractAddress: string, owner: string, spender: string): Promise<Allowance> {
+    try {
+      const queryMsgStr = JSON.stringify(CW20Schema.allowance)
+        .replace(CW20_ALLOWANCE_OWNER, owner)
+        .replace(CW20_ALLOWANCE_SPENDER, spender)
+      const queryMsg = JSON.parse(queryMsgStr)
+
+      const allowanceResp = await this.wasmService.queryContract(contractAddress, queryMsg)
+      allowanceResp.spender = spender
+
+      return allowanceResp as Allowance
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async allAllowances(
+    contractAddress: string,
+    owner: string,
+    options?: AndrSearchOptions,
+  ): Promise<Allowance[]> {
+    try {
+      const queryMsgStr = JSON.stringify(CW20Schema.all_allowances).replace(CW20_ALLOWANCE_OWNER, owner)
+      const queryMsg = JSON.parse(queryMsgStr)
+
+      if (options?.limit) queryMsg.all_allowances.limit = options?.limit
+      if (options?.startAfter) queryMsg.all_allowances.start_after = options?.startAfter
+
+      const allowancesResp = await this.wasmService.queryContract(contractAddress, queryMsg)
+
+      return (allowancesResp.allowances ?? []) as Allowance[]
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async allSpenderAllowances(
+    contractAddress: string,
+    spender: string,
+    options?: AndrSearchOptions,
+  ): Promise<Allowance[]> {
+    try {
+      const queryMsgStr = JSON.stringify(CW20Schema.all_spender_allowances).replace(CW20_ALLOWANCE_SPENDER, spender)
+      const queryMsg = JSON.parse(queryMsgStr)
+
+      if (options?.limit) queryMsg.all_spender_allowances.limit = options?.limit
+      if (options?.startAfter) queryMsg.all_spender_allowances.start_after = options?.startAfter
+
+      const allowancesResp = await this.wasmService.queryContract(contractAddress, queryMsg)
+
+      return (allowancesResp.allowances ?? []) as Allowance[]
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async allAccounts(contractAddress: string, options?: AndrSearchOptions): Promise<string[]> {
+    try {
+      const queryMsgStr = JSON.stringify(CW20Schema.all_accounts)
+      const queryMsg = JSON.parse(queryMsgStr)
+
+      if (options?.limit) queryMsg.all_accounts.limit = options?.limit
+      if (options?.startAfter) queryMsg.all_accounts.start_after = options?.startAfter
+
+      const allAccountsResp = await this.wasmService.queryContract(contractAddress, queryMsg)
+
+      return (allAccountsResp.accounts ?? []) as string[]
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async marketingInfo(contractAddress: string): Promise<MarketingInfo> {
+    try {
+      const marketingInfo = await this.wasmService.queryContract(contractAddress, CW20Schema.marketing_info)
+
+      return marketingInfo as MarketingInfo
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async downloadLogo(contractAddress: string): Promise<DownloadLogo> {
+    try {
+      const downloadLogo = await this.wasmService.queryContract(contractAddress, CW20Schema.download_logo)
+
+      return downloadLogo as DownloadLogo
     } catch (err: any) {
       this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
       if (err instanceof UserInputError || err instanceof ApolloError) {

--- a/src/ado/cw20/types/cw20.constants.ts
+++ b/src/ado/cw20/types/cw20.constants.ts
@@ -1,0 +1,3 @@
+export const CW20_BALANCE_ADDRESS = '<address>'
+export const CW20_ALLOWANCE_OWNER = '<owner_address>'
+export const CW20_ALLOWANCE_SPENDER = '<spender_address>'

--- a/src/ado/cw20/types/cw20.query.ts
+++ b/src/ado/cw20/types/cw20.query.ts
@@ -1,4 +1,5 @@
 import { Field, Int, Float, ObjectType } from '@nestjs/graphql'
+import GraphQLJSON from 'graphql-type-json'
 import { AndrQuery } from 'src/ado/andr-query/types'
 import { IBaseAdoQuery } from 'src/ado/types'
 
@@ -13,8 +14,32 @@ export class CW20Ado implements IBaseAdoQuery {
   @Field(() => AndrQuery)
   andr!: AndrQuery
 
+  @Field(() => Float, { nullable: true })
+  balance?: Promise<number>
+
   @Field(() => TokenInfo, { nullable: true })
   tokenInfo?: Promise<TokenInfo>
+
+  @Field(() => Minter, { nullable: true })
+  minter?: Promise<Minter>
+
+  @Field(() => Allowance, { nullable: true })
+  allowance?: Promise<Allowance>
+
+  @Field(() => [Allowance], { nullable: true })
+  allAllowances?: Promise<Allowance[]>
+
+  @Field(() => [Allowance], { nullable: true })
+  allSpenderAllowances?: Promise<Allowance[]>
+
+  @Field(() => [String], { nullable: true })
+  allAccounts?: Promise<string[]>
+
+  @Field(() => MarketingInfo, { nullable: true })
+  marketingInfo?: Promise<MarketingInfo>
+
+  @Field(() => DownloadLogo, { nullable: true })
+  downloadLogo?: Promise<DownloadLogo>
 }
 
 @ObjectType()
@@ -30,4 +55,55 @@ export class TokenInfo {
 
   @Field(() => Float)
   total_supply!: number
+}
+
+@ObjectType()
+export class Minter {
+  @Field()
+  minter!: string
+
+  @Field(() => Float, { nullable: true })
+  cap?: number
+}
+
+@ObjectType()
+export class Allowance {
+  @Field(() => String, { nullable: true })
+  owner?: string
+
+  @Field(() => String, { nullable: true })
+  spender?: string
+
+  @Field(() => Float, { nullable: true })
+  allowance?: number
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  expires?: Promise<JSON>
+}
+
+@ObjectType()
+export class MarketingInfo {
+  @Field(() => String, { nullable: true })
+  project?: string
+
+  @Field(() => String, { nullable: true })
+  description?: string
+
+  @Field(() => String, { nullable: true })
+  marketing?: string
+
+  @Field(() => Float, { nullable: true })
+  allowance?: number
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  logo?: Promise<JSON>
+}
+
+@ObjectType()
+export class DownloadLogo {
+  @Field(() => String, { nullable: true })
+  mime_type?: string
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  data?: Promise<JSON>
 }

--- a/src/ado/cw20/types/cw20.schema.ts
+++ b/src/ado/cw20/types/cw20.schema.ts
@@ -1,5 +1,40 @@
+import { CW20_ALLOWANCE_OWNER, CW20_ALLOWANCE_SPENDER, CW20_BALANCE_ADDRESS } from './cw20.constants'
+
 export const CW20Schema = {
+  balance: {
+    balance: {
+      address: CW20_BALANCE_ADDRESS,
+    },
+  },
   token_info: {
     token_info: {},
+  },
+  minter: {
+    minter: {},
+  },
+  allowance: {
+    allowance: {
+      owner: CW20_ALLOWANCE_OWNER,
+      spender: CW20_ALLOWANCE_SPENDER,
+    },
+  },
+  all_allowances: {
+    all_allowances: {
+      owner: CW20_ALLOWANCE_OWNER,
+    },
+  },
+  all_spender_allowances: {
+    all_spender_allowances: {
+      spender: CW20_ALLOWANCE_SPENDER,
+    },
+  },
+  all_accounts: {
+    all_accounts: {},
+  },
+  marketing_info: {
+    marketing_info: {},
+  },
+  download_logo: {
+    download_logo: {},
   },
 }

--- a/src/ado/cw20/types/index.ts
+++ b/src/ado/cw20/types/index.ts
@@ -1,2 +1,3 @@
-export { CW20Ado, TokenInfo } from './cw20.query'
+export { CW20Ado, TokenInfo, Minter, MarketingInfo, DownloadLogo } from './cw20.query'
+export { CW20_BALANCE_ADDRESS, CW20_ALLOWANCE_OWNER, CW20_ALLOWANCE_SPENDER } from './cw20.constants'
 export { CW20Schema } from './cw20.schema'

--- a/src/ado/cw20exchange/cw20exchange.module.ts
+++ b/src/ado/cw20exchange/cw20exchange.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+import { WasmModule } from 'src/wasm/wasm.module'
+import { CW20ExchangeResolver } from './cw20exchange.resolver'
+import { CW20ExchangeService } from './cw20exchange.service'
+
+@Module({
+  imports: [WasmModule],
+  providers: [CW20ExchangeResolver, CW20ExchangeService],
+})
+export class CW20ExchangeModule {}

--- a/src/ado/cw20exchange/cw20exchange.resolver.spec.ts
+++ b/src/ado/cw20exchange/cw20exchange.resolver.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { CW20ExchangeResolver } from './cw20exchange.resolver'
+import { CW20ExchangeService } from './cw20exchange.service'
+
+describe('CW20ExchangeResolver', () => {
+  let resolver: CW20ExchangeResolver
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CW20ExchangeResolver, { provide: CW20ExchangeService, useValue: {} }],
+    }).compile()
+
+    resolver = module.get<CW20ExchangeResolver>(CW20ExchangeResolver)
+  })
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined()
+  })
+})

--- a/src/ado/cw20exchange/cw20exchange.resolver.ts
+++ b/src/ado/cw20exchange/cw20exchange.resolver.ts
@@ -1,0 +1,31 @@
+import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql'
+import { AndrSearchOptions } from '../types'
+import { CW20ExchangeService } from './cw20exchange.service'
+import { CW20ExchangeAdo, SaleResponse } from './types'
+
+@Resolver(CW20ExchangeAdo)
+export class CW20ExchangeResolver {
+  constructor(private readonly cw20ExchangeService: CW20ExchangeService) {}
+
+  @ResolveField(() => SaleResponse)
+  public async sale(
+    @Parent() token: CW20ExchangeAdo,
+    @Args('cw20', { nullable: true }) cw20: string,
+    @Args('native', { nullable: true }) native: string,
+  ): Promise<SaleResponse> {
+    return this.cw20ExchangeService.sale(token.address, cw20, native)
+  }
+
+  @ResolveField(() => String)
+  public async tokenAddress(@Parent() token: CW20ExchangeAdo): Promise<string> {
+    return this.cw20ExchangeService.tokenAddress(token.address)
+  }
+
+  @ResolveField(() => String)
+  public async saleAssets(
+    @Parent() token: CW20ExchangeAdo,
+    @Args('options', { nullable: true }) options: AndrSearchOptions,
+  ): Promise<string> {
+    return this.cw20ExchangeService.saleAssets(token.address, options)
+  }
+}

--- a/src/ado/cw20exchange/cw20exchange.service.spec.ts
+++ b/src/ado/cw20exchange/cw20exchange.service.spec.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getLoggerToken } from 'nestjs-pino'
+import { WasmService } from 'src/wasm/wasm.service'
+import { CW20ExchangeService } from './cw20exchange.service'
+
+describe('CW20StakingService', () => {
+  let service: CW20ExchangeService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CW20ExchangeService,
+        {
+          provide: getLoggerToken(CW20ExchangeService.name),
+          useValue: {
+            error: jest.fn(),
+          },
+        },
+        {
+          provide: WasmService,
+          useValue: {},
+        },
+      ],
+    }).compile()
+
+    service = module.get<CW20ExchangeService>(CW20ExchangeService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+})

--- a/src/ado/cw20exchange/cw20exchange.service.ts
+++ b/src/ado/cw20exchange/cw20exchange.service.ts
@@ -1,0 +1,82 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { ApolloError, UserInputError } from 'apollo-server'
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
+import { WasmService } from 'src/wasm/wasm.service'
+import { AdoService } from '../ado.service'
+import { AndrSearchOptions } from '../types'
+import { INVALID_QUERY_ERR } from '../types/ado.constants'
+import { ASSET_INFO_NOT_FOUND_ERR, CW20ExchangeSchema, SaleResponse } from './types'
+
+@Injectable()
+export class CW20ExchangeService extends AdoService {
+  constructor(
+    @InjectPinoLogger(CW20ExchangeService.name)
+    protected readonly logger: PinoLogger,
+    @Inject(WasmService)
+    protected readonly wasmService: WasmService,
+  ) {
+    super(logger, wasmService)
+  }
+
+  public async sale(contractAddress: string, cw20?: string, native?: string): Promise<SaleResponse> {
+    try {
+      const queryMsgStr = JSON.stringify(CW20ExchangeSchema.sale)
+      const queryMsg = JSON.parse(queryMsgStr)
+
+      if (cw20) {
+        queryMsg.sale.asset.asset_info.cw20 = cw20
+      } else if (native) {
+        queryMsg.sale.asset.asset_info.native = native
+      } else {
+        throw new UserInputError(ASSET_INFO_NOT_FOUND_ERR)
+      }
+
+      const saleResp = await this.wasmService.queryContract(contractAddress, queryMsg)
+
+      return (saleResp.sale ?? null) as SaleResponse
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async tokenAddress(contractAddress: string): Promise<string> {
+    try {
+      const tokenResp = await this.wasmService.queryContract(contractAddress, CW20ExchangeSchema.token_address)
+
+      return (tokenResp.address ?? '') as string
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async saleAssets(contractAddress: string, options?: AndrSearchOptions): Promise<string> {
+    try {
+      const queryMsgStr = JSON.stringify(CW20ExchangeSchema.sale_assets)
+      const queryMsg = JSON.parse(queryMsgStr)
+
+      if (options?.limit) queryMsg.sale_assets.limit = options?.limit
+      if (options?.startAfter) queryMsg.sale_assets.start_after = options?.startAfter
+
+      const tokenResp = await this.wasmService.queryContract(contractAddress, queryMsg)
+
+      return (tokenResp.assets ?? '') as string
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+}

--- a/src/ado/cw20exchange/types/cw20exchange.constants.ts
+++ b/src/ado/cw20exchange/types/cw20exchange.constants.ts
@@ -1,0 +1,1 @@
+export const ASSET_INFO_NOT_FOUND_ERR = 'asset of the sale not found'

--- a/src/ado/cw20exchange/types/cw20exchange.query.ts
+++ b/src/ado/cw20exchange/types/cw20exchange.query.ts
@@ -1,0 +1,33 @@
+import { Field, Float, ObjectType } from '@nestjs/graphql'
+import { AndrQuery } from 'src/ado/andr-query/types'
+import { IBaseAdoQuery } from 'src/ado/types'
+
+@ObjectType({ implements: IBaseAdoQuery })
+export class CW20ExchangeAdo implements IBaseAdoQuery {
+  @Field()
+  address!: string
+
+  @Field()
+  type!: string
+
+  @Field(() => AndrQuery)
+  andr!: AndrQuery
+
+  @Field(() => SaleResponse, { nullable: true })
+  sale?: Promise<SaleResponse>
+
+  @Field(() => String, { nullable: true })
+  tokenAddress?: Promise<string>
+}
+
+@ObjectType()
+export class SaleResponse {
+  @Field(() => Float, { nullable: true })
+  exchange_rate?: number
+
+  @Field(() => Float, { nullable: true })
+  amount?: number
+
+  @Field(() => String, { nullable: true })
+  recipient?: string
+}

--- a/src/ado/cw20exchange/types/cw20exchange.schema.ts
+++ b/src/ado/cw20exchange/types/cw20exchange.schema.ts
@@ -1,0 +1,15 @@
+export const CW20ExchangeSchema = {
+  sale: {
+    sale: {
+      asset: {
+        asset_info: {},
+      },
+    },
+  },
+  token_address: {
+    token_address: {},
+  },
+  sale_assets: {
+    sale_assets: {},
+  },
+}

--- a/src/ado/cw20exchange/types/index.ts
+++ b/src/ado/cw20exchange/types/index.ts
@@ -1,0 +1,3 @@
+export { CW20ExchangeAdo, SaleResponse } from './cw20exchange.query'
+export { ASSET_INFO_NOT_FOUND_ERR } from './cw20exchange.constants'
+export { CW20ExchangeSchema } from './cw20exchange.schema'

--- a/src/ado/cw20staking/cw20staking.module.ts
+++ b/src/ado/cw20staking/cw20staking.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+import { WasmModule } from 'src/wasm/wasm.module'
+import { CW20StakingResolver } from './cw20staking.resolver'
+import { CW20StakingService } from './cw20staking.service'
+
+@Module({
+  imports: [WasmModule],
+  providers: [CW20StakingResolver, CW20StakingService],
+})
+export class CW20StakingModule {}

--- a/src/ado/cw20staking/cw20staking.resolver.spec.ts
+++ b/src/ado/cw20staking/cw20staking.resolver.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { CW20StakingResolver } from './cw20staking.resolver'
+import { CW20StakingService } from './cw20staking.service'
+
+describe('CW20StakingResolver', () => {
+  let resolver: CW20StakingResolver
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CW20StakingResolver, { provide: CW20StakingService, useValue: {} }],
+    }).compile()
+
+    resolver = module.get<CW20StakingResolver>(CW20StakingResolver)
+  })
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined()
+  })
+})

--- a/src/ado/cw20staking/cw20staking.resolver.ts
+++ b/src/ado/cw20staking/cw20staking.resolver.ts
@@ -1,0 +1,38 @@
+import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql'
+import GraphQLJSON from 'graphql-type-json'
+import { AndrSearchOptions } from '../types'
+import { CW20StakingService } from './cw20staking.service'
+import { ConfigStructure, CW20StakingAdo, StakerResponse, StateStructure } from './types'
+
+@Resolver(CW20StakingAdo)
+export class CW20StakingResolver {
+  constructor(private readonly cw20StakingService: CW20StakingService) {}
+
+  @ResolveField(() => ConfigStructure)
+  public async config(@Parent() token: CW20StakingAdo): Promise<ConfigStructure> {
+    return this.cw20StakingService.config(token.address)
+  }
+
+  @ResolveField(() => StateStructure)
+  public async state(@Parent() token: CW20StakingAdo): Promise<StateStructure> {
+    return this.cw20StakingService.state(token.address)
+  }
+
+  @ResolveField(() => StakerResponse)
+  public async staker(@Parent() token: CW20StakingAdo, @Args('address') address: string): Promise<StakerResponse> {
+    return this.cw20StakingService.staker(token.address, address)
+  }
+
+  @ResolveField(() => [StakerResponse])
+  public async stakers(
+    @Parent() token: CW20StakingAdo,
+    @Args('options', { nullable: true }) options: AndrSearchOptions,
+  ): Promise<StakerResponse[]> {
+    return this.cw20StakingService.stakers(token.address, options)
+  }
+
+  @ResolveField(() => GraphQLJSON)
+  public async timestamp(@Parent() token: CW20StakingAdo): Promise<JSON> {
+    return this.cw20StakingService.timestamp(token.address)
+  }
+}

--- a/src/ado/cw20staking/cw20staking.service.spec.ts
+++ b/src/ado/cw20staking/cw20staking.service.spec.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getLoggerToken } from 'nestjs-pino'
+import { WasmService } from 'src/wasm/wasm.service'
+import { CW20StakingService } from './cw20staking.service'
+
+describe('CW20StakingService', () => {
+  let service: CW20StakingService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CW20StakingService,
+        {
+          provide: getLoggerToken(CW20StakingService.name),
+          useValue: {
+            error: jest.fn(),
+          },
+        },
+        {
+          provide: WasmService,
+          useValue: {},
+        },
+      ],
+    }).compile()
+
+    service = module.get<CW20StakingService>(CW20StakingService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+})

--- a/src/ado/cw20staking/cw20staking.service.ts
+++ b/src/ado/cw20staking/cw20staking.service.ts
@@ -1,0 +1,103 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { ApolloError, UserInputError } from 'apollo-server'
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
+import { WasmService } from 'src/wasm/wasm.service'
+import { AdoService } from '../ado.service'
+import { AndrSearchOptions } from '../types'
+import { INVALID_QUERY_ERR } from '../types/ado.constants'
+import { ConfigStructure, CW20StakingSchema, StakerResponse, CW20_STAKER_ADDRESS, StateStructure } from './types'
+
+@Injectable()
+export class CW20StakingService extends AdoService {
+  constructor(
+    @InjectPinoLogger(CW20StakingService.name)
+    protected readonly logger: PinoLogger,
+    @Inject(WasmService)
+    protected readonly wasmService: WasmService,
+  ) {
+    super(logger, wasmService)
+  }
+
+  public async config(contractAddress: string): Promise<ConfigStructure> {
+    try {
+      const configResp = await this.wasmService.queryContract(contractAddress, CW20StakingSchema.config)
+
+      return configResp as ConfigStructure
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async state(contractAddress: string): Promise<StateStructure> {
+    try {
+      const configResp = await this.wasmService.queryContract(contractAddress, CW20StakingSchema.state)
+
+      return configResp as StateStructure
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async staker(contractAddress: string, address: string): Promise<StakerResponse> {
+    try {
+      const queryMsgStr = JSON.stringify(CW20StakingSchema.staker).replace(CW20_STAKER_ADDRESS, address)
+      const queryMsg = JSON.parse(queryMsgStr)
+
+      const stakerResp = await this.wasmService.queryContract(contractAddress, queryMsg)
+      return stakerResp as StakerResponse
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async stakers(contractAddress: string, options?: AndrSearchOptions): Promise<StakerResponse[]> {
+    try {
+      const queryMsgStr = JSON.stringify(CW20StakingSchema.stakers)
+      const queryMsg = JSON.parse(queryMsgStr)
+
+      if (options?.limit) queryMsg.stakers.limit = options?.limit
+      if (options?.startAfter) queryMsg.stakers.start_after = options?.startAfter
+
+      const stakersResp = await this.wasmService.queryContract(contractAddress, queryMsg)
+
+      return stakersResp as StakerResponse[]
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async timestamp(contractAddress: string): Promise<JSON> {
+    try {
+      const timestamp = await this.wasmService.queryContract(contractAddress, CW20StakingSchema.timestamp)
+
+      return timestamp as JSON
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+}

--- a/src/ado/cw20staking/types/cw20staking.constants.ts
+++ b/src/ado/cw20staking/types/cw20staking.constants.ts
@@ -1,0 +1,1 @@
+export const CW20_STAKER_ADDRESS = '<address>'

--- a/src/ado/cw20staking/types/cw20staking.query.ts
+++ b/src/ado/cw20staking/types/cw20staking.query.ts
@@ -1,0 +1,60 @@
+import { Field, Float, Int, ObjectType } from '@nestjs/graphql'
+import { AndrQuery } from 'src/ado/andr-query/types'
+import { IBaseAdoQuery } from 'src/ado/types'
+
+@ObjectType({ implements: IBaseAdoQuery })
+export class CW20StakingAdo implements IBaseAdoQuery {
+  @Field()
+  address!: string
+
+  @Field()
+  type!: string
+
+  @Field(() => AndrQuery)
+  andr!: AndrQuery
+
+  @Field(() => ConfigStructure, { nullable: true })
+  config?: Promise<ConfigStructure>
+
+  @Field(() => StateStructure, { nullable: true })
+  state?: Promise<StateStructure>
+
+  @Field(() => StakerResponse, { nullable: true })
+  staker?: Promise<StakerResponse>
+
+  @Field(() => [StakerResponse], { nullable: true })
+  stakers?: Promise<StakerResponse[]>
+}
+
+@ObjectType()
+export class ConfigStructure {
+  @Field(() => AndrAddress, { nullable: true })
+  staking_token?: Promise<AndrAddress>
+
+  @Field(() => Int, { nullable: true })
+  number_of_reward_tokens?: number
+}
+
+@ObjectType()
+export class AndrAddress {
+  @Field()
+  identifier?: string
+}
+
+@ObjectType()
+export class StateStructure {
+  @Field(() => Float, { nullable: true })
+  total_share?: number
+}
+
+@ObjectType()
+export class StakerResponse {
+  @Field()
+  address?: string
+
+  @Field(() => Float, { nullable: true })
+  share?: number
+
+  @Field(() => [[String, Float]], { nullable: true })
+  pending_rewards?: [string, number][]
+}

--- a/src/ado/cw20staking/types/cw20staking.schema.ts
+++ b/src/ado/cw20staking/types/cw20staking.schema.ts
@@ -1,0 +1,21 @@
+import { CW20_STAKER_ADDRESS } from './cw20staking.constants'
+
+export const CW20StakingSchema = {
+  config: {
+    config: {},
+  },
+  state: {
+    state: {},
+  },
+  staker: {
+    staker: {
+      address: CW20_STAKER_ADDRESS,
+    },
+  },
+  stakers: {
+    stakers: {},
+  },
+  timestamp: {
+    timestamp: {},
+  },
+}

--- a/src/ado/cw20staking/types/index.ts
+++ b/src/ado/cw20staking/types/index.ts
@@ -1,0 +1,3 @@
+export { CW20StakingAdo, ConfigStructure, StateStructure, StakerResponse } from './cw20staking.query'
+export { CW20_STAKER_ADDRESS } from './cw20staking.constants'
+export { CW20StakingSchema } from './cw20staking.schema'

--- a/src/ado/types/ado.enums.ts
+++ b/src/ado/types/ado.enums.ts
@@ -30,6 +30,7 @@ export enum AdoType {
   App = 'app',
   Crowdfund = 'crowdfund',
   CW20Staking = 'cw20-staking',
+  CW20Exchange = 'cw20-exchange',
   CW20 = 'cw20',
   CW721 = 'cw721',
   CW721Bids = 'cw721-bids',

--- a/src/ado/types/ado.query.ts
+++ b/src/ado/types/ado.query.ts
@@ -4,6 +4,8 @@ import { AppAdo } from '../app/types'
 import { AuctionAdo } from '../auction/types'
 import { CrowdfundAdo } from '../crowdfund/types'
 import { CW20Ado } from '../cw20/types'
+import { CW20ExchangeAdo } from '../cw20exchange/types'
+import { CW20StakingAdo } from '../cw20staking/types'
 import { CW721Ado } from '../cw721/types'
 import { MarketplaceAdo } from '../marketplace/types'
 import { PrimitiveAdo } from '../primitive/types'
@@ -41,8 +43,11 @@ export class AdoQuery {
   @Field(() => CW20Ado)
   cw20!: Promise<CW20Ado>
 
-  @Field()
-  cw20_staking!: string
+  @Field(() => CW20StakingAdo)
+  cw20_staking!: Promise<CW20StakingAdo>
+
+  @Field(() => CW20ExchangeAdo)
+  cw20_exchange!: Promise<CW20ExchangeAdo>
 
   @Field(() => AuctionAdo)
   auction!: Promise<AuctionAdo>

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,8 @@ import { AppAdoModule } from './ado/app/app-ado.module'
 import { AuctionModule } from './ado/auction/auction.module'
 import { CrowdfundModule } from './ado/crowdfund/crowdfund.module'
 import { CW20Module } from './ado/cw20/cw20.module'
+import { CW20ExchangeModule } from './ado/cw20exchange/cw20exchange.module'
+import { CW20StakingModule } from './ado/cw20staking/cw20staking.module'
 import { CW721Module } from './ado/cw721/cw721.module'
 import { FactoryModule } from './ado/factory/factory.module'
 import { MarketplaceModule } from './ado/marketplace/marketplace.module'
@@ -111,6 +113,8 @@ import { WasmModule } from './wasm/wasm.module'
     AuctionModule,
     CrowdfundModule,
     CW20Module,
+    CW20StakingModule,
+    CW20ExchangeModule,
     FactoryModule,
     CW721Module,
     KeplrConfigModule,

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -67,7 +67,8 @@ type AdoQuery {
   auction(address: String!): AuctionAdo!
   crowdfund(address: String!): CrowdfundAdo!
   cw20(address: String!): CW20Ado!
-  cw20_staking: String!
+  cw20_exchange(address: String!): CW20ExchangeAdo!
+  cw20_staking(address: String!): CW20StakingAdo!
   cw721(address: String!): CW721Ado!
   factory(address: String!): FactoryAdo!
   marketplace(address: String!): MarketplaceAdo!
@@ -85,6 +86,7 @@ enum AdoType {
   App
   Auction
   CW20
+  CW20Exchange
   CW20Staking
   CW721
   CW721Bids
@@ -122,6 +124,17 @@ type AgreementAmount {
 type AllNftInfo {
   access: NftOwnerInfo
   info: NftInfo
+}
+
+type Allowance {
+  allowance: Float
+  expires: JSON
+  owner: String
+  spender: String
+}
+
+type AndrAddress {
+  identifier: String!
 }
 
 enum AndrOrderBy {
@@ -286,8 +299,36 @@ type Bip44 {
 
 type CW20Ado {
   address: String!
+  allAccounts(options: AndrSearchOptions): [String!]
+  allAllowances(options: AndrSearchOptions, owner: String!): [Allowance!]
+  allSpenderAllowances(options: AndrSearchOptions, spender: String!): [Allowance!]
+  allowance(owner: String!, spender: String!): Allowance
   andr: AndrQuery!
+  balance(address: String!): Float
+  downloadLogo: DownloadLogo
+  marketingInfo: MarketingInfo
+  minter: Minter
   tokenInfo: TokenInfo
+  type: String!
+}
+
+type CW20ExchangeAdo {
+  address: String!
+  andr: AndrQuery!
+  sale(cw20: String, native: String): SaleResponse
+  saleAssets(options: AndrSearchOptions): String!
+  tokenAddress: String
+  type: String!
+}
+
+type CW20StakingAdo {
+  address: String!
+  andr: AndrQuery!
+  config: ConfigStructure
+  staker(address: String!): StakerResponse
+  stakers(options: AndrSearchOptions): [StakerResponse!]
+  state: StateStructure
+  timestamp: JSON!
   type: String!
 }
 
@@ -353,6 +394,11 @@ type Component {
   name: String!
 }
 
+type ConfigStructure {
+  number_of_reward_tokens: Int
+  staking_token: AndrAddress
+}
+
 type CrowdfundAdo {
   address: String!
   andr: AndrQuery!
@@ -384,6 +430,11 @@ type Currency {
   coinDenom: String!
   coinGeckoId: String!
   coinMinimalDenom: String!
+}
+
+type DownloadLogo {
+  data: JSON
+  mime_type: String
 }
 
 type Escrow {
@@ -455,6 +506,14 @@ type KeplrConfigQuery {
   config(identifier: String!): KeplrConfig!
 }
 
+type MarketingInfo {
+  allowance: Float
+  description: String
+  logo: JSON
+  marketing: String
+  project: String
+}
+
 type MarketplaceAdo {
   address: String!
   andr: AndrQuery!
@@ -469,6 +528,11 @@ type MetadataAttribute {
   display_type: String
   trait_type: String!
   value: String!
+}
+
+type Minter {
+  cap: Float
+  minter: String!
 }
 
 type NftApproval {
@@ -551,6 +615,12 @@ type SaleInfo {
   token_id: String
 }
 
+type SaleResponse {
+  amount: Float
+  exchange_rate: Float
+  recipient: String
+}
+
 type SaleStateResponse {
   coin_denom: String
   price: String
@@ -573,6 +643,16 @@ type SplitterAdo {
   andr: AndrQuery!
   config: Splitter
   type: String!
+}
+
+type StakerResponse {
+  address: String!
+  pending_rewards: [[String!]!]
+  share: Float
+}
+
+type StateStructure {
+  total_share: Float
 }
 
 type SummaryFields {


### PR DESCRIPTION
# Motivation

- Implemented queries for Usecase4 ADOs(CW20, CW20 Staking, CW20 Exchange)

# Implementation
The following queries were added
CW20
 - Balance
 - TokenInfo
 - Minter
 - Allowance
 - AllAllowances
 - AllSpenderAllowances
 - AllAccounts
 - MarketingInfo
 - DownloadLogo
 - andr(A set of base queries common to all Andromeda ADOs)

CW20 Staking
 - Config
 - State
 - Staker
 - Stakers
 - Timestamp
- andr(A set of base queries common to all Andromeda ADOs)

CW20 Exchange
 - Sale
 - TokenAddress
 - SaleAssets
- andr(A set of base queries common to all Andromeda ADOs)

# Testing
- Tested all the queries using playground - Working as expected

# Notes
N/A

# Future work
N/A
