### PR TITLE
Fix NFT token URI

### DIFF
--- a/src/ado/cw721/types/cw721.query.ts
+++ b/src/ado/cw721/types/cw721.query.ts
@@ -146,8 +146,8 @@ export class AttributeSearchOptions {
 
 @ObjectType()
 export class NftInfo {
-  @Field({ nullable: true })
-  tokenUri?: string
+  @Field(() => String, { nullable: true })
+  token_uri?: string
 
   @Field(() => TokenExtension, { nullable: true })
   extension?: TokenExtension


### PR DESCRIPTION
# Motivation
Fixed issue with tokenURI from CW721 queries "NFT INFO" always returning null for the TokenURI field

# Implementation
Changed field name from tokenUrl to token_url

# Testing
- Tested the queries nftInfo & allNftInfo using playground - Working as expected
- Executed npm run test - No tests failed

# Notes
N/A

# Future work
N/A
