### PR TITLE
Usecase5 ADOs

### DIFF
--- a/src/ado/ado.resolver.ts
+++ b/src/ado/ado.resolver.ts
@@ -10,14 +10,19 @@ import { CW20ExchangeAdo } from './cw20exchange/types'
 import { CW20StakingAdo } from './cw20staking/types'
 import { CW721Ado } from './cw721/types'
 import { FactoryAdo } from './factory/types'
+import { LockdropAdo } from './lockdrop/types'
 import { MarketplaceAdo } from './marketplace/types'
+import { MerkleAirdropAdo } from './merkle-airdrop/types'
 import { PrimitiveAdo } from './primitive/types'
+import { RateLimitingWithdrawalsAdo } from './rate-limiting-withdrawals/types'
 import { RatesAdo } from './rates/types'
 import { SplitterAdo } from './splitter/types'
 import { TimelockAdo } from './timelock/types'
 import { AdoQuery } from './types'
 import { BaseAdo } from './types/base-ado.query'
 import { VaultAdo } from './vault/types'
+import { VestingAdo } from './vesting/types'
+import { WeightedDistributionSplitterAdo } from './weighted-distribution-splitter/types'
 
 @Resolver(AdoQuery)
 export class AdoResolver {
@@ -46,6 +51,11 @@ export class AdoResolver {
   @ResolveField(() => AuctionAdo)
   public async auction(@Args('address') address: string): Promise<AuctionAdo> {
     return this.adoService.getAdo<AuctionAdo>(address, AdoType.Auction)
+  }
+
+  @ResolveField(() => LockdropAdo)
+  public async lockdrop(@Args('address') address: string): Promise<LockdropAdo> {
+    return this.adoService.getAdo<LockdropAdo>(address, AdoType.Lockdrop)
   }
 
   @ResolveField(() => CrowdfundAdo)
@@ -83,9 +93,19 @@ export class AdoResolver {
     return this.adoService.getAdo<MarketplaceAdo>(address, AdoType.Marketplace)
   }
 
+  @ResolveField(() => MerkleAirdropAdo)
+  public async merkle_airdrop(@Args('address') address: string): Promise<MerkleAirdropAdo> {
+    return this.adoService.getAdo<MerkleAirdropAdo>(address, AdoType.MerkleAirdrop)
+  }
+
   @ResolveField(() => PrimitiveAdo)
   public async primitive(@Args('address') address: string): Promise<PrimitiveAdo> {
     return this.adoService.getAdo<PrimitiveAdo>(address, AdoType.Primitive)
+  }
+
+  @ResolveField(() => RateLimitingWithdrawalsAdo)
+  public async rate_limiting_withdrawals(@Args('address') address: string): Promise<RateLimitingWithdrawalsAdo> {
+    return this.adoService.getAdo<RateLimitingWithdrawalsAdo>(address, AdoType.RateLimitingWithdrawals)
   }
 
   @ResolveField(() => RatesAdo)
@@ -106,5 +126,17 @@ export class AdoResolver {
   @ResolveField(() => VaultAdo)
   public async vault(@Args('address') address: string): Promise<VaultAdo> {
     return this.adoService.getAdo<VaultAdo>(address, AdoType.Vault)
+  }
+
+  @ResolveField(() => VestingAdo)
+  public async vesting(@Args('address') address: string): Promise<VestingAdo> {
+    return this.adoService.getAdo<VestingAdo>(address, AdoType.Vesting)
+  }
+
+  @ResolveField(() => WeightedDistributionSplitterAdo)
+  public async weighted_distribution_splitter(
+    @Args('address') address: string,
+  ): Promise<WeightedDistributionSplitterAdo> {
+    return this.adoService.getAdo<WeightedDistributionSplitterAdo>(address, AdoType.WeightedDistributionSplitter)
   }
 }

--- a/src/ado/lockdrop/lockdrop.module.ts
+++ b/src/ado/lockdrop/lockdrop.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+import { WasmModule } from 'src/wasm/wasm.module'
+import { LockdropResolver } from './lockdrop.resolver'
+import { LockdropService } from './lockdrop.service'
+
+@Module({
+  imports: [WasmModule],
+  providers: [LockdropResolver, LockdropService],
+})
+export class LockdropModule {}

--- a/src/ado/lockdrop/lockdrop.resolver.spec.ts
+++ b/src/ado/lockdrop/lockdrop.resolver.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { LockdropResolver } from './lockdrop.resolver'
+import { LockdropService } from './lockdrop.service'
+
+describe('LockdropResolver', () => {
+  let resolver: LockdropResolver
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [LockdropResolver, { provide: LockdropService, useValue: {} }],
+    }).compile()
+
+    resolver = module.get<LockdropResolver>(LockdropResolver)
+  })
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined()
+  })
+})

--- a/src/ado/lockdrop/lockdrop.resolver.ts
+++ b/src/ado/lockdrop/lockdrop.resolver.ts
@@ -1,0 +1,31 @@
+import { Args, Float, Parent, ResolveField, Resolver } from '@nestjs/graphql'
+import { LockdropService } from './lockdrop.service'
+import { LockdropAdo, LockdropConfig, LockdropState, LockdropUserInfo } from './types'
+
+@Resolver(LockdropAdo)
+export class LockdropResolver {
+  constructor(private readonly lockdropService: LockdropService) {}
+
+  @ResolveField(() => LockdropState)
+  public async state(@Parent() lockdrop: LockdropAdo): Promise<LockdropState> {
+    return this.lockdropService.state(lockdrop.address)
+  }
+
+  @ResolveField(() => LockdropConfig)
+  public async config(@Parent() lockdrop: LockdropAdo): Promise<LockdropConfig> {
+    return this.lockdropService.config(lockdrop.address)
+  }
+
+  @ResolveField(() => [LockdropUserInfo])
+  public async userInfo(@Parent() lockdrop: LockdropAdo, @Args('user') user: string): Promise<LockdropUserInfo> {
+    return this.lockdropService.userInfo(lockdrop.address, user)
+  }
+
+  @ResolveField(() => Float)
+  public async withdrawalPercentAllowed(
+    @Parent() lockdrop: LockdropAdo,
+    @Args('timestamp') timestamp: number,
+  ): Promise<number> {
+    return this.lockdropService.withdrawalPercentAllowed(lockdrop.address, timestamp)
+  }
+}

--- a/src/ado/lockdrop/lockdrop.service.spec.ts
+++ b/src/ado/lockdrop/lockdrop.service.spec.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getLoggerToken } from 'nestjs-pino'
+import { WasmService } from 'src/wasm/wasm.service'
+import { LockdropService } from './lockdrop.service'
+
+describe('LockdropService', () => {
+  let service: LockdropService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LockdropService,
+        {
+          provide: getLoggerToken(LockdropService.name),
+          useValue: {
+            error: jest.fn(),
+          },
+        },
+        {
+          provide: WasmService,
+          useValue: {},
+        },
+      ],
+    }).compile()
+
+    service = module.get<LockdropService>(LockdropService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+})

--- a/src/ado/lockdrop/lockdrop.service.ts
+++ b/src/ado/lockdrop/lockdrop.service.ts
@@ -1,0 +1,91 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { ApolloError, UserInputError } from 'apollo-server'
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
+import { WasmService } from 'src/wasm/wasm.service'
+import { AdoService } from '../ado.service'
+import { DEFAULT_CATCH_ERR, INVALID_QUERY_ERR } from '../types'
+import {
+  LockdropConfig,
+  LockdropSchema,
+  LockdropState,
+  LockdropUserInfo,
+  LOCKDROP_TIMESTAMP,
+  LOCKDROP_USER_ADDRESS,
+} from './types'
+
+@Injectable()
+export class LockdropService extends AdoService {
+  constructor(
+    @InjectPinoLogger(LockdropService.name)
+    protected readonly logger: PinoLogger,
+    @Inject(WasmService)
+    protected readonly wasmService: WasmService,
+  ) {
+    super(logger, wasmService)
+  }
+
+  public async state(address: string): Promise<LockdropState> {
+    try {
+      const lockdropState = await this.wasmService.queryContract(address, LockdropSchema.state)
+      return lockdropState as LockdropState
+    } catch (err: any) {
+      this.logger.error({ err }, DEFAULT_CATCH_ERR, address)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async config(address: string): Promise<LockdropConfig> {
+    try {
+      const lockdropConfig = await this.wasmService.queryContract(address, LockdropSchema.config)
+      return lockdropConfig as LockdropConfig
+    } catch (err: any) {
+      this.logger.error({ err }, DEFAULT_CATCH_ERR, address)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async userInfo(address: string, user: string): Promise<LockdropUserInfo> {
+    try {
+      const queryMsgStr = JSON.stringify(LockdropSchema.user_info).replace(LOCKDROP_USER_ADDRESS, user)
+      const queryMsg = JSON.parse(queryMsgStr)
+
+      const queryResponse = await this.wasmService.queryContract(address, queryMsg)
+      return queryResponse as LockdropUserInfo
+    } catch (err: any) {
+      this.logger.error({ err }, DEFAULT_CATCH_ERR, address)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async withdrawalPercentAllowed(address: string, timestamp: number): Promise<number> {
+    try {
+      const queryMsgStr = JSON.stringify(LockdropSchema.withdrawal_percent_allowed).replace(
+        '"' + LOCKDROP_TIMESTAMP + '"',
+        String(timestamp),
+      )
+      const queryMsg = JSON.parse(queryMsgStr)
+
+      const queryResponse = await this.wasmService.queryContract(address, queryMsg)
+      return queryResponse as number
+    } catch (err: any) {
+      this.logger.error({ err }, DEFAULT_CATCH_ERR, address)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+}

--- a/src/ado/lockdrop/types/index.ts
+++ b/src/ado/lockdrop/types/index.ts
@@ -1,0 +1,3 @@
+export { LockdropAdo, LockdropConfig, LockdropState, LockdropUserInfo } from './lockdrop.query'
+export { LOCKDROP_TIMESTAMP, LOCKDROP_USER_ADDRESS } from './lockdrop.constants'
+export { LockdropSchema } from './lockdrop.schema'

--- a/src/ado/lockdrop/types/lockdrop.constants.ts
+++ b/src/ado/lockdrop/types/lockdrop.constants.ts
@@ -1,0 +1,2 @@
+export const LOCKDROP_USER_ADDRESS = '<address>'
+export const LOCKDROP_TIMESTAMP = '<timestamp>'

--- a/src/ado/lockdrop/types/lockdrop.query.ts
+++ b/src/ado/lockdrop/types/lockdrop.query.ts
@@ -1,0 +1,72 @@
+import { Field, Float, Int, ObjectType } from '@nestjs/graphql'
+import { AndrQuery } from 'src/ado/andr-query/types'
+import { IBaseAdoQuery } from 'src/ado/types'
+
+@ObjectType({ implements: IBaseAdoQuery })
+export class LockdropAdo implements IBaseAdoQuery {
+  @Field()
+  address!: string
+
+  @Field()
+  type!: string
+
+  @Field(() => AndrQuery)
+  andr!: AndrQuery
+
+  @Field(() => LockdropState, { nullable: true })
+  state?: Promise<LockdropState>
+
+  @Field(() => LockdropConfig, { nullable: true })
+  config?: Promise<LockdropConfig>
+
+  @Field(() => [LockdropUserInfo], { nullable: true })
+  userInfo?: Promise<LockdropUserInfo>
+
+  @Field(() => Float, { nullable: true })
+  withdrawalPercentAllowed?: Promise<number>
+}
+
+@ObjectType()
+export class LockdropState {
+  @Field(() => String, { nullable: true })
+  total_native_locked?: string
+
+  @Field(() => Boolean, { nullable: true })
+  are_claims_allowed?: boolean
+}
+
+@ObjectType()
+export class LockdropConfig {
+  @Field(() => Int, { nullable: true })
+  init_timestamp?: number
+
+  @Field(() => Int, { nullable: true })
+  deposit_window?: number
+
+  @Field(() => Int, { nullable: true })
+  withdrawal_window?: number
+
+  @Field(() => Int, { nullable: true })
+  lockdrop_incentives?: number
+
+  @Field(() => String, { nullable: true })
+  incentive_token?: string
+
+  @Field(() => String, { nullable: true })
+  native_denom?: string
+}
+
+@ObjectType()
+export class LockdropUserInfo {
+  @Field(() => String, { nullable: true })
+  total_native_locked?: string
+
+  @Field(() => String, { nullable: true })
+  total_incentives?: string
+
+  @Field(() => Boolean, { nullable: true })
+  is_lockdrop_claimed?: boolean
+
+  @Field(() => Boolean, { nullable: true })
+  withrawal_flag?: boolean
+}

--- a/src/ado/lockdrop/types/lockdrop.schema.ts
+++ b/src/ado/lockdrop/types/lockdrop.schema.ts
@@ -1,0 +1,20 @@
+import { LOCKDROP_TIMESTAMP, LOCKDROP_USER_ADDRESS } from './lockdrop.constants'
+
+export const LockdropSchema = {
+  state: {
+    state: {},
+  },
+  config: {
+    config: {},
+  },
+  user_info: {
+    user_info: {
+      address: LOCKDROP_USER_ADDRESS,
+    },
+  },
+  withdrawal_percent_allowed: {
+    withdrawal_percent_allowed: {
+      timestamp: LOCKDROP_TIMESTAMP,
+    },
+  },
+}

--- a/src/ado/merkle-airdrop/merkle-airdrop.module.ts
+++ b/src/ado/merkle-airdrop/merkle-airdrop.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+import { WasmModule } from 'src/wasm/wasm.module'
+import { MerkleAirdropResolver } from './merkle-airdrop.resolver'
+import { MerkleAirdropService } from './merkle-airdrop.service'
+
+@Module({
+  imports: [WasmModule],
+  providers: [MerkleAirdropResolver, MerkleAirdropService],
+})
+export class MerkleAirdropModule {}

--- a/src/ado/merkle-airdrop/merkle-airdrop.resolver.spec.ts
+++ b/src/ado/merkle-airdrop/merkle-airdrop.resolver.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { MerkleAirdropResolver } from './merkle-airdrop.resolver'
+import { MerkleAirdropService } from './merkle-airdrop.service'
+
+describe('CrowdfundResolver', () => {
+  let resolver: MerkleAirdropResolver
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MerkleAirdropResolver, { provide: MerkleAirdropService, useValue: {} }],
+    }).compile()
+
+    resolver = module.get<MerkleAirdropResolver>(MerkleAirdropResolver)
+  })
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined()
+  })
+})

--- a/src/ado/merkle-airdrop/merkle-airdrop.resolver.ts
+++ b/src/ado/merkle-airdrop/merkle-airdrop.resolver.ts
@@ -1,0 +1,40 @@
+import { Args, Int, Parent, ResolveField, Resolver } from '@nestjs/graphql'
+import { MerkleAirdropService } from './merkle-airdrop.service'
+import { MerkleAirdropAdo, MerkleAirdropConfig, MerkleRootResponse } from './types'
+
+@Resolver(MerkleAirdropAdo)
+export class MerkleAirdropResolver {
+  constructor(private readonly merkleAirdropService: MerkleAirdropService) {}
+
+  @ResolveField(() => MerkleAirdropConfig)
+  public async config(@Parent() merkleAirdrop: MerkleAirdropAdo): Promise<MerkleAirdropConfig> {
+    return this.merkleAirdropService.config(merkleAirdrop.address)
+  }
+
+  @ResolveField(() => MerkleRootResponse)
+  public async merkleRoot(
+    @Parent() merkleAirdrop: MerkleAirdropAdo,
+    @Args('stage') stage: number,
+  ): Promise<MerkleRootResponse> {
+    return this.merkleAirdropService.merkleRoot(merkleAirdrop.address, stage)
+  }
+
+  @ResolveField(() => Int)
+  public async latestStage(@Parent() merkleAirdrop: MerkleAirdropAdo): Promise<number> {
+    return this.merkleAirdropService.latestStage(merkleAirdrop.address)
+  }
+
+  @ResolveField(() => Boolean)
+  public async isClaimed(
+    @Parent() merkleAirdrop: MerkleAirdropAdo,
+    @Args('stage') stage: number,
+    @Args('address') address: string,
+  ): Promise<boolean> {
+    return this.merkleAirdropService.isClaimed(merkleAirdrop.address, stage, address)
+  }
+
+  @ResolveField(() => String)
+  public async totalClaimed(@Parent() merkleAirdrop: MerkleAirdropAdo, @Args('stage') stage: number): Promise<string> {
+    return this.merkleAirdropService.totalClaimed(merkleAirdrop.address, stage)
+  }
+}

--- a/src/ado/merkle-airdrop/merkle-airdrop.service.spec.ts
+++ b/src/ado/merkle-airdrop/merkle-airdrop.service.spec.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getLoggerToken } from 'nestjs-pino'
+import { WasmService } from 'src/wasm/wasm.service'
+import { MerkleAirdropService } from './merkle-airdrop.service'
+
+describe('CrowdfundService', () => {
+  let service: MerkleAirdropService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MerkleAirdropService,
+        {
+          provide: getLoggerToken(MerkleAirdropService.name),
+          useValue: {
+            error: jest.fn(),
+          },
+        },
+        {
+          provide: WasmService,
+          useValue: {},
+        },
+      ],
+    }).compile()
+
+    service = module.get<MerkleAirdropService>(MerkleAirdropService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+})

--- a/src/ado/merkle-airdrop/merkle-airdrop.service.ts
+++ b/src/ado/merkle-airdrop/merkle-airdrop.service.ts
@@ -1,0 +1,112 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { ApolloError, UserInputError } from 'apollo-server'
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
+import { WasmService } from 'src/wasm/wasm.service'
+import { AdoService } from '../ado.service'
+import { DEFAULT_CATCH_ERR, INVALID_QUERY_ERR } from '../types'
+import {
+  MerkleAirdropConfig,
+  MerkleAirdropSchema,
+  MerkleRootResponse,
+  MERKLE_AIRDROP_ADDRESS,
+  MERKLE_AIRDROP_STAGE,
+} from './types'
+
+@Injectable()
+export class MerkleAirdropService extends AdoService {
+  constructor(
+    @InjectPinoLogger(MerkleAirdropService.name)
+    protected readonly logger: PinoLogger,
+    @Inject(WasmService)
+    protected readonly wasmService: WasmService,
+  ) {
+    super(logger, wasmService)
+  }
+
+  public async config(address: string): Promise<MerkleAirdropConfig> {
+    try {
+      const MerkleRootConfig = await this.wasmService.queryContract(address, MerkleAirdropSchema.config)
+      return MerkleRootConfig as MerkleAirdropConfig
+    } catch (err: any) {
+      this.logger.error({ err }, DEFAULT_CATCH_ERR, address)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async merkleRoot(address: string, stage: number): Promise<MerkleRootResponse> {
+    const queryMsgStr = JSON.stringify(MerkleAirdropSchema.merkle_root).replace(
+      '"' + MERKLE_AIRDROP_STAGE + '"',
+      String(stage),
+    )
+    const queryMsg = JSON.parse(queryMsgStr)
+
+    try {
+      const queryResponse = await this.wasmService.queryContract(address, queryMsg)
+      return queryResponse as MerkleRootResponse
+    } catch (err: any) {
+      this.logger.error({ err }, DEFAULT_CATCH_ERR, address)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async latestStage(address: string): Promise<number> {
+    try {
+      const queryResponse = await this.wasmService.queryContract(address, MerkleAirdropSchema.latest_stage)
+      return (queryResponse.latest_stage as number) ?? 0
+    } catch (err: any) {
+      this.logger.error({ err }, DEFAULT_CATCH_ERR, address)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async isClaimed(contractAddress: string, stage: number, address: string): Promise<boolean> {
+    const queryMsgStr = JSON.stringify(MerkleAirdropSchema.is_claimed)
+      .replace('"' + MERKLE_AIRDROP_STAGE + '"', String(stage))
+      .replace(MERKLE_AIRDROP_ADDRESS, address)
+    const queryMsg = JSON.parse(queryMsgStr)
+
+    try {
+      const queryResponse = await this.wasmService.queryContract(contractAddress, queryMsg)
+      return queryResponse as boolean
+    } catch (err: any) {
+      this.logger.error({ err }, DEFAULT_CATCH_ERR, contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async totalClaimed(contractAddress: string, stage: number): Promise<string> {
+    const queryMsgStr = JSON.stringify(MerkleAirdropSchema.total_claimed).replace(
+      '"' + MERKLE_AIRDROP_STAGE + '"',
+      String(stage),
+    )
+    const queryMsg = JSON.parse(queryMsgStr)
+
+    try {
+      const queryResponse = await this.wasmService.queryContract(contractAddress, queryMsg)
+      return queryResponse as string
+    } catch (err: any) {
+      this.logger.error({ err }, DEFAULT_CATCH_ERR, contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+}

--- a/src/ado/merkle-airdrop/types/index.ts
+++ b/src/ado/merkle-airdrop/types/index.ts
@@ -1,0 +1,3 @@
+export { MerkleAirdropAdo, MerkleAirdropConfig, MerkleRootResponse } from './merkle-airdrop.query'
+export { MERKLE_AIRDROP_ADDRESS, MERKLE_AIRDROP_STAGE } from './merkle-airdrop.constants'
+export { MerkleAirdropSchema } from './merkle-airdrop.schema'

--- a/src/ado/merkle-airdrop/types/merkle-airdrop.constants.ts
+++ b/src/ado/merkle-airdrop/types/merkle-airdrop.constants.ts
@@ -1,0 +1,2 @@
+export const MERKLE_AIRDROP_STAGE = '<stage>'
+export const MERKLE_AIRDROP_ADDRESS = '<address>'

--- a/src/ado/merkle-airdrop/types/merkle-airdrop.query.ts
+++ b/src/ado/merkle-airdrop/types/merkle-airdrop.query.ts
@@ -1,0 +1,52 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql'
+import GraphQLJSON from 'graphql-type-json'
+import { AndrQuery } from 'src/ado/andr-query/types'
+import { IBaseAdoQuery } from 'src/ado/types'
+
+@ObjectType({ implements: IBaseAdoQuery })
+export class MerkleAirdropAdo implements IBaseAdoQuery {
+  @Field()
+  address!: string
+
+  @Field()
+  type!: string
+
+  @Field(() => AndrQuery)
+  andr!: AndrQuery
+
+  @Field(() => MerkleAirdropConfig, { nullable: true })
+  config?: Promise<MerkleAirdropConfig>
+
+  @Field(() => MerkleRootResponse, { nullable: true })
+  merkleRoot?: Promise<MerkleRootResponse>
+
+  @Field(() => Int, { nullable: true })
+  latestStage?: Promise<number>
+
+  @Field(() => Boolean, { nullable: true })
+  isClaimed?: Promise<boolean>
+
+  @Field(() => String, { nullable: true })
+  totalClaimed?: Promise<string>
+}
+
+@ObjectType()
+export class MerkleAirdropConfig {
+  @Field(() => GraphQLJSON, { nullable: true })
+  asset_info?: JSON
+}
+
+@ObjectType()
+export class MerkleRootResponse {
+  @Field(() => Int, { nullable: true })
+  stage?: number
+
+  @Field(() => String, { nullable: true })
+  merkle_root?: string
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  expiration?: JSON
+
+  @Field(() => String, { nullable: true })
+  total_amount?: string
+}

--- a/src/ado/merkle-airdrop/types/merkle-airdrop.schema.ts
+++ b/src/ado/merkle-airdrop/types/merkle-airdrop.schema.ts
@@ -1,0 +1,26 @@
+import { MERKLE_AIRDROP_ADDRESS, MERKLE_AIRDROP_STAGE } from './merkle-airdrop.constants'
+
+export const MerkleAirdropSchema = {
+  config: {
+    config: {},
+  },
+  merkle_root: {
+    merkle_root: {
+      stage: MERKLE_AIRDROP_STAGE,
+    },
+  },
+  latest_stage: {
+    latest_stage: {},
+  },
+  is_claimed: {
+    is_claimed: {
+      stage: MERKLE_AIRDROP_STAGE,
+      address: MERKLE_AIRDROP_ADDRESS,
+    },
+  },
+  total_claimed: {
+    total_claimed: {
+      stage: MERKLE_AIRDROP_STAGE,
+    },
+  },
+}

--- a/src/ado/rate-limiting-withdrawals/rate-limiting-withdrawals.module.ts
+++ b/src/ado/rate-limiting-withdrawals/rate-limiting-withdrawals.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+import { WasmModule } from 'src/wasm/wasm.module'
+import { RateLimitingWithdrawalsResolver } from './rate-limiting-withdrawals.resolver'
+import { RateLimitingWithdrawalsService } from './rate-limiting-withdrawals.service'
+
+@Module({
+  imports: [WasmModule],
+  providers: [RateLimitingWithdrawalsResolver, RateLimitingWithdrawalsService],
+})
+export class RateLimitingWithdrawalsModule {}

--- a/src/ado/rate-limiting-withdrawals/rate-limiting-withdrawals.resolver.spec.ts
+++ b/src/ado/rate-limiting-withdrawals/rate-limiting-withdrawals.resolver.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { RateLimitingWithdrawalsResolver } from './rate-limiting-withdrawals.resolver'
+import { RateLimitingWithdrawalsService } from './rate-limiting-withdrawals.service'
+
+describe('TimelockResolver', () => {
+  let resolver: RateLimitingWithdrawalsResolver
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RateLimitingWithdrawalsResolver, { provide: RateLimitingWithdrawalsService, useValue: {} }],
+    }).compile()
+
+    resolver = module.get<RateLimitingWithdrawalsResolver>(RateLimitingWithdrawalsResolver)
+  })
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined()
+  })
+})

--- a/src/ado/rate-limiting-withdrawals/rate-limiting-withdrawals.resolver.ts
+++ b/src/ado/rate-limiting-withdrawals/rate-limiting-withdrawals.resolver.ts
@@ -1,0 +1,23 @@
+import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql'
+import { RateLimitingWithdrawalsService } from './rate-limiting-withdrawals.service'
+import { AccountDetails, CoinAllowance, RateLimitingWithdrawalsAdo } from './types'
+
+@Resolver(RateLimitingWithdrawalsAdo)
+export class RateLimitingWithdrawalsResolver {
+  constructor(private readonly rateLimitingWithdrawalsService: RateLimitingWithdrawalsService) {}
+
+  @ResolveField(() => CoinAllowance)
+  public async coinAllowanceDetails(
+    @Parent() rateLimitingWithdrawals: RateLimitingWithdrawalsAdo,
+  ): Promise<CoinAllowance> {
+    return this.rateLimitingWithdrawalsService.coinAllowanceDetails(rateLimitingWithdrawals.address)
+  }
+
+  @ResolveField(() => AccountDetails)
+  public async accountDetails(
+    @Parent() rateLimitingWithdrawals: RateLimitingWithdrawalsAdo,
+    @Args('account') account: string,
+  ): Promise<AccountDetails> {
+    return this.rateLimitingWithdrawalsService.accountDetails(rateLimitingWithdrawals.address, account)
+  }
+}

--- a/src/ado/rate-limiting-withdrawals/rate-limiting-withdrawals.service.spec.ts
+++ b/src/ado/rate-limiting-withdrawals/rate-limiting-withdrawals.service.spec.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getLoggerToken } from 'nestjs-pino'
+import { WasmService } from 'src/wasm/wasm.service'
+import { RateLimitingWithdrawalsService } from './rate-limiting-withdrawals.service'
+
+describe('RateLimitingWithdrawalsService', () => {
+  let service: RateLimitingWithdrawalsService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RateLimitingWithdrawalsService,
+        {
+          provide: getLoggerToken(RateLimitingWithdrawalsService.name),
+          useValue: {
+            error: jest.fn(),
+          },
+        },
+        {
+          provide: WasmService,
+          useValue: {},
+        },
+      ],
+    }).compile()
+
+    service = module.get<RateLimitingWithdrawalsService>(RateLimitingWithdrawalsService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+})

--- a/src/ado/rate-limiting-withdrawals/rate-limiting-withdrawals.service.ts
+++ b/src/ado/rate-limiting-withdrawals/rate-limiting-withdrawals.service.ts
@@ -1,0 +1,61 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { ApolloError, UserInputError } from 'apollo-server'
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
+import { WasmService } from 'src/wasm/wasm.service'
+import { AdoService } from '../ado.service'
+import { INVALID_QUERY_ERR } from '../types/ado.constants'
+import {
+  AccountDetails,
+  CoinAllowance,
+  RateLimitingWithdrawalsSchema,
+  RATE_LIMITING_WITHDRAWALS_ACCOUNT,
+} from './types'
+
+@Injectable()
+export class RateLimitingWithdrawalsService extends AdoService {
+  constructor(
+    @InjectPinoLogger(RateLimitingWithdrawalsService.name)
+    protected readonly logger: PinoLogger,
+    @Inject(WasmService)
+    protected readonly wasmService: WasmService,
+  ) {
+    super(logger, wasmService)
+  }
+
+  public async coinAllowanceDetails(contractAddress: string): Promise<CoinAllowance> {
+    try {
+      const queryResp = await this.wasmService.queryContract(
+        contractAddress,
+        RateLimitingWithdrawalsSchema.coin_allowed_details,
+      )
+      return queryResp as CoinAllowance
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async accountDetails(contractAddress: string, account: string): Promise<AccountDetails> {
+    const queryMsgStr = JSON.stringify(RateLimitingWithdrawalsSchema.account_details).replace(
+      RATE_LIMITING_WITHDRAWALS_ACCOUNT,
+      account,
+    )
+    const queryMsg = JSON.parse(queryMsgStr)
+
+    try {
+      const queryResp = await this.wasmService.queryContract(contractAddress, queryMsg)
+      return queryResp as AccountDetails
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+}

--- a/src/ado/rate-limiting-withdrawals/types/index.ts
+++ b/src/ado/rate-limiting-withdrawals/types/index.ts
@@ -1,0 +1,3 @@
+export { AccountDetails, CoinAllowance, RateLimitingWithdrawalsAdo } from './rate-limiting-withdrawals.query'
+export { RATE_LIMITING_WITHDRAWALS_ACCOUNT } from './rate-limiting-withdrawals.constants'
+export { RateLimitingWithdrawalsSchema } from './rate-limiting-withdrawals.schema'

--- a/src/ado/rate-limiting-withdrawals/types/rate-limiting-withdrawals.constants.ts
+++ b/src/ado/rate-limiting-withdrawals/types/rate-limiting-withdrawals.constants.ts
@@ -1,0 +1,1 @@
+export const RATE_LIMITING_WITHDRAWALS_ACCOUNT = '<account>'

--- a/src/ado/rate-limiting-withdrawals/types/rate-limiting-withdrawals.query.ts
+++ b/src/ado/rate-limiting-withdrawals/types/rate-limiting-withdrawals.query.ts
@@ -1,0 +1,42 @@
+import { Field, ObjectType } from '@nestjs/graphql'
+import { AndrQuery } from 'src/ado/andr-query/types'
+import { IBaseAdoQuery } from 'src/ado/types'
+
+@ObjectType({ implements: IBaseAdoQuery })
+export class RateLimitingWithdrawalsAdo implements IBaseAdoQuery {
+  @Field()
+  address!: string
+
+  @Field()
+  type!: string
+
+  @Field(() => AndrQuery)
+  andr!: AndrQuery
+
+  @Field(() => CoinAllowance, { nullable: true })
+  coinAllowanceDetails?: Promise<CoinAllowance>
+
+  @Field(() => AccountDetails, { nullable: true })
+  accountDetails?: Promise<AccountDetails>
+}
+
+@ObjectType()
+export class CoinAllowance {
+  @Field(() => String, { nullable: true })
+  coin?: string
+
+  @Field(() => String, { nullable: true })
+  limit?: string
+
+  @Field(() => String, { nullable: true })
+  minimal_withdrawal_frequency?: string
+}
+
+@ObjectType()
+export class AccountDetails {
+  @Field(() => String, { nullable: true })
+  balance?: string
+
+  @Field(() => String, { nullable: true })
+  latest_withdrawal?: string
+}

--- a/src/ado/rate-limiting-withdrawals/types/rate-limiting-withdrawals.schema.ts
+++ b/src/ado/rate-limiting-withdrawals/types/rate-limiting-withdrawals.schema.ts
@@ -1,0 +1,12 @@
+import { RATE_LIMITING_WITHDRAWALS_ACCOUNT } from './rate-limiting-withdrawals.constants'
+
+export const RateLimitingWithdrawalsSchema = {
+  coin_allowed_details: {
+    coin_allowed_details: {},
+  },
+  account_details: {
+    account_details: {
+      account: RATE_LIMITING_WITHDRAWALS_ACCOUNT,
+    },
+  },
+}

--- a/src/ado/splitter/types/splitter.query.ts
+++ b/src/ado/splitter/types/splitter.query.ts
@@ -32,6 +32,6 @@ export class Splitter {
   @Field(() => [AddressPercent], { nullable: true })
   recipients?: AddressPercent[]
 
-  @Field(() => Boolean, { nullable: true })
-  locked?: boolean
+  @Field(() => GraphQLJSON, { nullable: true })
+  lock?: Promise<JSON>
 }

--- a/src/ado/timelock/timelock.resolver.ts
+++ b/src/ado/timelock/timelock.resolver.ts
@@ -22,6 +22,6 @@ export class TimelockResolver {
     @Args('recipient') recipient: string,
     @Args('options') options?: AndrSearchOptions,
   ): Promise<Escrow[]> {
-    return [] as Escrow[]
+    return this.timelockService.getLockedFundsForRecipient(timelock.address, recipient, options)
   }
 }

--- a/src/ado/timelock/types/timelock.schema.ts
+++ b/src/ado/timelock/types/timelock.schema.ts
@@ -7,4 +7,9 @@ export const TimelockSchema = {
       recipient: TIMELOCK_QUERY_RECIPIENT,
     },
   },
+  locked_funds_for_recipient: {
+    get_locked_funds_for_recipient: {
+      recipient: TIMELOCK_QUERY_RECIPIENT,
+    },
+  },
 }

--- a/src/ado/types/ado.query.ts
+++ b/src/ado/types/ado.query.ts
@@ -7,11 +7,17 @@ import { CW20Ado } from '../cw20/types'
 import { CW20ExchangeAdo } from '../cw20exchange/types'
 import { CW20StakingAdo } from '../cw20staking/types'
 import { CW721Ado } from '../cw721/types'
+import { LockdropAdo } from '../lockdrop/types'
 import { MarketplaceAdo } from '../marketplace/types'
+import { MerkleAirdropAdo } from '../merkle-airdrop/types'
 import { PrimitiveAdo } from '../primitive/types'
+import { RateLimitingWithdrawalsAdo } from '../rate-limiting-withdrawals/types'
 import { RatesAdo } from '../rates/types'
 import { SplitterAdo } from '../splitter/types'
+import { TimelockAdo } from '../timelock/types'
 import { VaultAdo } from '../vault/types'
+import { VestingAdo } from '../vesting/types'
+import { WeightedDistributionSplitterAdo } from '../weighted-distribution-splitter/types'
 import { BaseAdo } from './base-ado.query'
 
 @ObjectType()
@@ -30,6 +36,12 @@ export class AdoQuery {
 
   @Field(() => VaultAdo)
   vault!: Promise<VaultAdo>
+
+  @Field(() => VestingAdo)
+  vesting!: Promise<VestingAdo>
+
+  @Field(() => RateLimitingWithdrawalsAdo)
+  rate_limiting_withdrawals!: Promise<RateLimitingWithdrawalsAdo>
 
   @Field(() => RatesAdo)
   rates!: Promise<RatesAdo>
@@ -52,11 +64,23 @@ export class AdoQuery {
   @Field(() => AuctionAdo)
   auction!: Promise<AuctionAdo>
 
+  @Field(() => LockdropAdo)
+  lockdrop!: Promise<LockdropAdo>
+
   @Field(() => MarketplaceAdo)
   marketplace!: Promise<MarketplaceAdo>
 
+  @Field(() => MerkleAirdropAdo)
+  merkle_airdrop!: Promise<MerkleAirdropAdo>
+
   @Field(() => CrowdfundAdo)
   crowdfund!: Promise<CrowdfundAdo>
+
+  @Field(() => TimelockAdo)
+  timelock!: Promise<TimelockAdo>
+
+  @Field(() => WeightedDistributionSplitterAdo)
+  weighted_distribution_splitter!: Promise<WeightedDistributionSplitterAdo>
 
   @Field(() => AppAdo)
   app!: Promise<AppAdo>

--- a/src/ado/vesting/types/index.ts
+++ b/src/ado/vesting/types/index.ts
@@ -1,0 +1,3 @@
+export { VestingAdo, VestingConfig, VestingBatchInfo } from './vesting.query'
+export { VESTING_BATCH_ID } from './vesting.constants'
+export { VestingSchema } from './vesting.schema'

--- a/src/ado/vesting/types/vesting.constants.ts
+++ b/src/ado/vesting/types/vesting.constants.ts
@@ -1,0 +1,1 @@
+export const VESTING_BATCH_ID = '<batch_id>'

--- a/src/ado/vesting/types/vesting.query.ts
+++ b/src/ado/vesting/types/vesting.query.ts
@@ -1,0 +1,70 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql'
+import GraphQLJSON from 'graphql-type-json'
+import { AndrQuery } from 'src/ado/andr-query/types'
+import { IBaseAdoQuery } from 'src/ado/types'
+
+@ObjectType({ implements: IBaseAdoQuery })
+export class VestingAdo implements IBaseAdoQuery {
+  @Field()
+  address!: string
+
+  @Field()
+  type!: string
+
+  @Field(() => AndrQuery)
+  andr!: AndrQuery
+
+  @Field(() => VestingConfig, { nullable: true })
+  config?: Promise<VestingConfig>
+
+  @Field(() => VestingBatchInfo, { nullable: true })
+  batch?: Promise<VestingBatchInfo>
+
+  @Field(() => [VestingBatchInfo], { nullable: true })
+  batches?: Promise<VestingBatchInfo[]>
+}
+
+@ObjectType()
+export class VestingConfig {
+  @Field(() => GraphQLJSON, { nullable: true })
+  recipient?: JSON
+
+  @Field(() => Boolean, { nullable: true })
+  is_multi_batch_enabled?: boolean
+
+  @Field(() => String, { nullable: true })
+  denom?: string
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  unbonding_duration?: JSON
+}
+
+@ObjectType()
+export class VestingBatchInfo {
+  @Field(() => Int, { nullable: true })
+  id?: number
+
+  @Field(() => String, { nullable: true })
+  amount?: string
+
+  @Field(() => String, { nullable: true })
+  amount_claimed?: string
+
+  @Field(() => String, { nullable: true })
+  amount_available_to_claim?: string
+
+  @Field(() => String, { nullable: true })
+  number_of_available_claims?: string
+
+  @Field(() => Int, { nullable: true })
+  lockup_end?: number
+
+  @Field(() => Int, { nullable: true })
+  release_unit?: number
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  release_amount?: JSON
+
+  @Field(() => Int, { nullable: true })
+  last_claimed_release_time?: number
+}

--- a/src/ado/vesting/types/vesting.schema.ts
+++ b/src/ado/vesting/types/vesting.schema.ts
@@ -1,0 +1,18 @@
+import { VESTING_BATCH_ID } from './vesting.constants'
+
+export const VestingSchema = {
+  state: {
+    state: {},
+  },
+  config: {
+    config: {},
+  },
+  batch: {
+    batch: {
+      id: VESTING_BATCH_ID,
+    },
+  },
+  batches: {
+    batches: {},
+  },
+}

--- a/src/ado/vesting/vesting.module.ts
+++ b/src/ado/vesting/vesting.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+import { WasmModule } from 'src/wasm/wasm.module'
+import { VestingResolver } from './vesting.resolver'
+import { VestingService } from './vesting.service'
+
+@Module({
+  imports: [WasmModule],
+  providers: [VestingResolver, VestingService],
+})
+export class VestingModule {}

--- a/src/ado/vesting/vesting.resolver.spec.ts
+++ b/src/ado/vesting/vesting.resolver.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { VestingResolver } from './vesting.resolver'
+import { VestingService } from './vesting.service'
+
+describe('VestingResolver', () => {
+  let resolver: VestingResolver
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [VestingResolver, { provide: VestingService, useValue: {} }],
+    }).compile()
+
+    resolver = module.get<VestingResolver>(VestingResolver)
+  })
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined()
+  })
+})

--- a/src/ado/vesting/vesting.resolver.ts
+++ b/src/ado/vesting/vesting.resolver.ts
@@ -1,0 +1,23 @@
+import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql'
+import { VestingAdo, VestingConfig, VestingBatchInfo } from './types'
+import { VestingService } from './vesting.service'
+
+@Resolver(VestingAdo)
+export class VestingResolver {
+  constructor(private readonly vestingService: VestingService) {}
+
+  @ResolveField(() => VestingConfig)
+  public async config(@Parent() vesting: VestingAdo): Promise<VestingConfig> {
+    return this.vestingService.config(vesting.address)
+  }
+
+  @ResolveField(() => VestingBatchInfo)
+  public async batch(@Parent() vesting: VestingAdo, @Args('id') id: number): Promise<VestingBatchInfo> {
+    return this.vestingService.batch(vesting.address, id)
+  }
+
+  @ResolveField(() => [VestingBatchInfo])
+  public async batches(@Parent() vesting: VestingAdo): Promise<VestingBatchInfo[]> {
+    return this.vestingService.batches(vesting.address)
+  }
+}

--- a/src/ado/vesting/vesting.service.spec.ts
+++ b/src/ado/vesting/vesting.service.spec.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getLoggerToken } from 'nestjs-pino'
+import { WasmService } from 'src/wasm/wasm.service'
+import { VestingService } from './vesting.service'
+
+describe('VestingService', () => {
+  let service: VestingService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        VestingService,
+        {
+          provide: getLoggerToken(VestingService.name),
+          useValue: {
+            error: jest.fn(),
+          },
+        },
+        {
+          provide: WasmService,
+          useValue: {},
+        },
+      ],
+    }).compile()
+
+    service = module.get<VestingService>(VestingService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+})

--- a/src/ado/vesting/vesting.service.ts
+++ b/src/ado/vesting/vesting.service.ts
@@ -1,0 +1,64 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { ApolloError, UserInputError } from 'apollo-server'
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
+import { WasmService } from 'src/wasm/wasm.service'
+import { AdoService } from '../ado.service'
+import { DEFAULT_CATCH_ERR, INVALID_QUERY_ERR } from '../types'
+import { VestingConfig, VestingSchema, VestingBatchInfo, VESTING_BATCH_ID } from './types'
+
+@Injectable()
+export class VestingService extends AdoService {
+  constructor(
+    @InjectPinoLogger(VestingService.name)
+    protected readonly logger: PinoLogger,
+    @Inject(WasmService)
+    protected readonly wasmService: WasmService,
+  ) {
+    super(logger, wasmService)
+  }
+
+  public async config(address: string): Promise<VestingConfig> {
+    try {
+      const lockdropConfig = await this.wasmService.queryContract(address, VestingSchema.config)
+      return lockdropConfig as VestingConfig
+    } catch (err: any) {
+      this.logger.error({ err }, DEFAULT_CATCH_ERR, address)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async batch(address: string, id: number): Promise<VestingBatchInfo> {
+    try {
+      const queryMsgStr = JSON.stringify(VestingSchema.batch).replace('"' + VESTING_BATCH_ID + '"', String(id))
+      const queryMsg = JSON.parse(queryMsgStr)
+
+      const queryResponse = await this.wasmService.queryContract(address, queryMsg)
+      return queryResponse as VestingBatchInfo
+    } catch (err: any) {
+      this.logger.error({ err }, DEFAULT_CATCH_ERR, address)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async batches(address: string): Promise<VestingBatchInfo[]> {
+    try {
+      const queryResponse = await this.wasmService.queryContract(address, VestingSchema.batches)
+      return queryResponse as VestingBatchInfo[]
+    } catch (err: any) {
+      this.logger.error({ err }, DEFAULT_CATCH_ERR, address)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+}

--- a/src/ado/weighted-distribution-splitter/types/index.ts
+++ b/src/ado/weighted-distribution-splitter/types/index.ts
@@ -1,0 +1,3 @@
+export { UserWeightResponse, WeightedDistributionSplitterAdo } from './weighted-distribution-splitter.query'
+export { USER_ADDRESS } from './weighted-distribution-splitter.constants'
+export { WeightedDistributionSplitterSchema } from './weighted-distribution-splitter.schema'

--- a/src/ado/weighted-distribution-splitter/types/weighted-distribution-splitter.constants.ts
+++ b/src/ado/weighted-distribution-splitter/types/weighted-distribution-splitter.constants.ts
@@ -1,0 +1,1 @@
+export const USER_ADDRESS = '<addr>'

--- a/src/ado/weighted-distribution-splitter/types/weighted-distribution-splitter.query.ts
+++ b/src/ado/weighted-distribution-splitter/types/weighted-distribution-splitter.query.ts
@@ -1,0 +1,28 @@
+import { Field, Float, ObjectType } from '@nestjs/graphql'
+import { AndrQuery } from 'src/ado/andr-query/types'
+import { Splitter } from 'src/ado/splitter/types'
+import { IBaseAdoQuery } from 'src/ado/types'
+
+@ObjectType({ implements: IBaseAdoQuery })
+export class WeightedDistributionSplitterAdo implements IBaseAdoQuery {
+  @Field()
+  address!: string
+
+  @Field()
+  type!: string
+
+  @Field(() => AndrQuery)
+  andr!: AndrQuery
+
+  @Field(() => Splitter, { nullable: true })
+  config?: Promise<Splitter>
+}
+
+@ObjectType()
+export class UserWeightResponse {
+  @Field(() => Float, { nullable: true })
+  weight?: number
+
+  @Field(() => Float, { nullable: true })
+  total_weight?: number
+}

--- a/src/ado/weighted-distribution-splitter/types/weighted-distribution-splitter.schema.ts
+++ b/src/ado/weighted-distribution-splitter/types/weighted-distribution-splitter.schema.ts
@@ -1,0 +1,14 @@
+import { USER_ADDRESS } from './weighted-distribution-splitter.constants'
+
+export const WeightedDistributionSplitterSchema = {
+  config: {
+    get_splitter_config: {},
+  },
+  get_user_weight: {
+    get_user_weight: {
+      user: {
+        addr: USER_ADDRESS,
+      },
+    },
+  },
+}

--- a/src/ado/weighted-distribution-splitter/weighted-distribution-splitter.module.ts
+++ b/src/ado/weighted-distribution-splitter/weighted-distribution-splitter.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+import { WasmModule } from 'src/wasm/wasm.module'
+import { WeightedDistributionSplitterResolver } from './weighted-distribution-splitter.resolver'
+import { WeightedDistributionSplitterService } from './weighted-distribution-splitter.service'
+
+@Module({
+  imports: [WasmModule],
+  providers: [WeightedDistributionSplitterResolver, WeightedDistributionSplitterService],
+})
+export class WeightedDistributionSplitterModule {}

--- a/src/ado/weighted-distribution-splitter/weighted-distribution-splitter.resolver.spec.ts
+++ b/src/ado/weighted-distribution-splitter/weighted-distribution-splitter.resolver.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { WeightedDistributionSplitterResolver } from './weighted-distribution-splitter.resolver'
+import { WeightedDistributionSplitterService } from './weighted-distribution-splitter.service'
+
+describe('WeightedDistributionSplitterResolver', () => {
+  let resolver: WeightedDistributionSplitterResolver
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [WeightedDistributionSplitterResolver, { provide: WeightedDistributionSplitterService, useValue: {} }],
+    }).compile()
+
+    resolver = module.get<WeightedDistributionSplitterResolver>(WeightedDistributionSplitterResolver)
+  })
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined()
+  })
+})

--- a/src/ado/weighted-distribution-splitter/weighted-distribution-splitter.resolver.ts
+++ b/src/ado/weighted-distribution-splitter/weighted-distribution-splitter.resolver.ts
@@ -1,0 +1,22 @@
+import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql'
+import { Splitter } from '../splitter/types'
+import { UserWeightResponse, WeightedDistributionSplitterAdo } from './types'
+import { WeightedDistributionSplitterService } from './weighted-distribution-splitter.service'
+
+@Resolver(WeightedDistributionSplitterAdo)
+export class WeightedDistributionSplitterResolver {
+  constructor(private readonly wDSplitterService: WeightedDistributionSplitterService) {}
+
+  @ResolveField(() => Splitter)
+  public async config(@Parent() wDSplitter: WeightedDistributionSplitterAdo): Promise<Splitter> {
+    return this.wDSplitterService.config(wDSplitter.address)
+  }
+
+  @ResolveField(() => UserWeightResponse)
+  public async getUserWeight(
+    @Parent() wDSplitter: WeightedDistributionSplitterAdo,
+    @Args('user') user: string,
+  ): Promise<UserWeightResponse> {
+    return this.wDSplitterService.getUserWeight(wDSplitter.address, user)
+  }
+}

--- a/src/ado/weighted-distribution-splitter/weighted-distribution-splitter.service.spec.ts
+++ b/src/ado/weighted-distribution-splitter/weighted-distribution-splitter.service.spec.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getLoggerToken } from 'nestjs-pino'
+import { WasmService } from 'src/wasm/wasm.service'
+import { WeightedDistributionSplitterService } from './weighted-distribution-splitter.service'
+
+describe('WeightedDistributionSplitterService', () => {
+  let service: WeightedDistributionSplitterService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WeightedDistributionSplitterService,
+        {
+          provide: getLoggerToken(WeightedDistributionSplitterService.name),
+          useValue: {
+            error: jest.fn(),
+          },
+        },
+        {
+          provide: WasmService,
+          useValue: {},
+        },
+      ],
+    }).compile()
+
+    service = module.get<WeightedDistributionSplitterService>(WeightedDistributionSplitterService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+})

--- a/src/ado/weighted-distribution-splitter/weighted-distribution-splitter.service.ts
+++ b/src/ado/weighted-distribution-splitter/weighted-distribution-splitter.service.ts
@@ -1,0 +1,53 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { ApolloError, UserInputError } from 'apollo-server'
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
+import { WasmService } from 'src/wasm/wasm.service'
+import { AdoService } from '../ado.service'
+import { Splitter } from '../splitter/types'
+import { INVALID_QUERY_ERR } from '../types'
+import { UserWeightResponse, USER_ADDRESS, WeightedDistributionSplitterAdo } from './types'
+import { WeightedDistributionSplitterSchema } from './types'
+
+@Injectable()
+export class WeightedDistributionSplitterService extends AdoService {
+  constructor(
+    @InjectPinoLogger(WeightedDistributionSplitterService.name)
+    protected readonly logger: PinoLogger,
+    @Inject(WasmService)
+    protected readonly wasmService: WasmService,
+  ) {
+    super(logger, wasmService)
+  }
+
+  public async config(contractAddress: string): Promise<Splitter> {
+    try {
+      const splitter = await this.wasmService.queryContract(contractAddress, WeightedDistributionSplitterSchema.config)
+      return (splitter as WeightedDistributionSplitterAdo).config ?? {}
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+
+  public async getUserWeight(contractAddress: string, user: string): Promise<UserWeightResponse> {
+    try {
+      const queryMsgStr = JSON.stringify(WeightedDistributionSplitterSchema.get_user_weight).replace(USER_ADDRESS, user)
+      const queryMsg = JSON.parse(queryMsgStr)
+
+      const weight = await this.wasmService.queryContract(contractAddress, queryMsg)
+
+      return weight as UserWeightResponse
+    } catch (err: any) {
+      this.logger.error({ err }, 'Error getting the wasm contract %s query.', contractAddress)
+      if (err instanceof UserInputError || err instanceof ApolloError) {
+        throw err
+      }
+
+      throw new ApolloError(INVALID_QUERY_ERR)
+    }
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,13 +21,18 @@ import { CW20ExchangeModule } from './ado/cw20exchange/cw20exchange.module'
 import { CW20StakingModule } from './ado/cw20staking/cw20staking.module'
 import { CW721Module } from './ado/cw721/cw721.module'
 import { FactoryModule } from './ado/factory/factory.module'
+import { LockdropModule } from './ado/lockdrop/lockdrop.module'
 import { MarketplaceModule } from './ado/marketplace/marketplace.module'
+import { MerkleAirdropModule } from './ado/merkle-airdrop/merkle-airdrop.module'
 import { PrimitiveModule } from './ado/primitive/primitive.module'
+import { RateLimitingWithdrawalsAdo } from './ado/rate-limiting-withdrawals/types'
 import { RatesModule } from './ado/rates/rates.module'
 import { SplitterModule } from './ado/splitter/splitter.module'
 import { TimelockModule } from './ado/timelock/timelock.module'
 import { registerEnums } from './ado/types/ado.enums'
 import { VaultModule } from './ado/vault/vault.module'
+import { VestingModule } from './ado/vesting/vesting.module'
+import { WeightedDistributionSplitterModule } from './ado/weighted-distribution-splitter/weighted-distribution-splitter.module'
 import { ChainConfigModule } from './chain-config/chain-config.module'
 import { CosmModule } from './cosm'
 import { validate } from './env.validation'
@@ -111,6 +116,7 @@ import { WasmModule } from './wasm/wasm.module'
     AddresslistModule,
     AppAdoModule,
     AuctionModule,
+    LockdropModule,
     CrowdfundModule,
     CW20Module,
     CW20StakingModule,
@@ -119,11 +125,15 @@ import { WasmModule } from './wasm/wasm.module'
     CW721Module,
     KeplrConfigModule,
     PrimitiveModule,
+    RateLimitingWithdrawalsAdo,
     RatesModule,
     SplitterModule,
     TimelockModule,
+    WeightedDistributionSplitterModule,
     VaultModule,
+    VestingModule,
     MarketplaceModule,
+    MerkleAirdropModule,
     TxModule,
     WasmModule,
     AssetsModule,

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -25,8 +25,13 @@ type ADORate {
   key: String
 }
 
+type AccountDetails {
+  balance: String
+  latest_withdrawal: String
+}
+
 type AccountsQuery {
-  assets(adoType: AdoType, limit: Int = 10, offset: Int = 0, walletAddress: String!): [AssetResult!]!
+  assets(adoType: AdoType, limit: Int = 10, minter: String, offset: Int = 0, walletAddress: String): [AssetResult!]!
   wallets: String!
 }
 
@@ -71,13 +76,18 @@ type AdoQuery {
   cw20_staking(address: String!): CW20StakingAdo!
   cw721(address: String!): CW721Ado!
   factory(address: String!): FactoryAdo!
+  lockdrop(address: String!): LockdropAdo!
   marketplace(address: String!): MarketplaceAdo!
+  merkle_airdrop(address: String!): MerkleAirdropAdo!
   primitive(address: String!): PrimitiveAdo!
+  rate_limiting_withdrawals(address: String!): RateLimitingWithdrawalsAdo!
   rates(address: String!): RatesAdo!
   receipt: String!
   splitter(address: String!): SplitterAdo!
   timelock(address: String!): TimelockAdo!
   vault(address: String!): VaultAdo!
+  vesting(address: String!): VestingAdo!
+  weighted_distribution_splitter(address: String!): WeightedDistributionSplitterAdo!
 }
 
 enum AdoType {
@@ -387,6 +397,12 @@ type Coin {
   denom: String!
 }
 
+type CoinAllowance {
+  coin: String
+  limit: String
+  minimal_withdrawal_frequency: String
+}
+
 type Component {
   address: String
   ado_type: String!
@@ -506,6 +522,37 @@ type KeplrConfigQuery {
   config(identifier: String!): KeplrConfig!
 }
 
+type LockdropAdo {
+  address: String!
+  andr: AndrQuery!
+  config: LockdropConfig
+  state: LockdropState
+  type: String!
+  userInfo(user: String!): [LockdropUserInfo!]
+  withdrawalPercentAllowed(timestamp: Float!): Float
+}
+
+type LockdropConfig {
+  deposit_window: Int
+  incentive_token: String
+  init_timestamp: Int
+  lockdrop_incentives: Int
+  native_denom: String
+  withdrawal_window: Int
+}
+
+type LockdropState {
+  are_claims_allowed: Boolean
+  total_native_locked: String
+}
+
+type LockdropUserInfo {
+  is_lockdrop_claimed: Boolean
+  total_incentives: String
+  total_native_locked: String
+  withrawal_flag: Boolean
+}
+
 type MarketingInfo {
   allowance: Float
   description: String
@@ -522,6 +569,28 @@ type MarketplaceAdo {
   saleInfosForAddress(options: AndrSearchOptions, tokenAddress: String!): [SaleInfo!]
   saleState(saleId: String!): SaleStateResponse
   type: String!
+}
+
+type MerkleAirdropAdo {
+  address: String!
+  andr: AndrQuery!
+  config: MerkleAirdropConfig
+  isClaimed(address: String!, stage: Float!): Boolean
+  latestStage: Int
+  merkleRoot(stage: Float!): MerkleRootResponse
+  totalClaimed(stage: Float!): String
+  type: String!
+}
+
+type MerkleAirdropConfig {
+  asset_info: JSON
+}
+
+type MerkleRootResponse {
+  expiration: JSON
+  merkle_root: String
+  stage: Int
+  total_amount: String
 }
 
 type MetadataAttribute {
@@ -547,7 +616,7 @@ type NftContractInfo {
 
 type NftInfo {
   extension: TokenExtension
-  tokenUri: String
+  token_uri: String
 }
 
 type NftOwnerInfo {
@@ -576,7 +645,7 @@ type Query {
   ADOP: ADOPQuery!
   accounts: AccountsQuery!
   app(address: String!): AppAdo! @deprecated(reason: "Moved to `ADO` query resolver, use `app` field on `ADO` to resolve this query.")
-  assets(adoType: AdoType, limit: Int = 10, offset: Int = 0, walletAddress: String!): [AssetResult!]! @deprecated(reason: "Moved to `Accounts` query resolver, use `assets` field on `Accounts` to resolve this query.")
+  assets(adoType: AdoType, limit: Int = 10, minter: String!, offset: Int = 0, walletAddress: String!): [AssetResult!]! @deprecated(reason: "Moved to `Accounts` query resolver, use `assets` field on `Accounts` to resolve this query.")
   auction(address: String!): AuctionAdo! @deprecated(reason: "Moved to `ADO` query resolver, use `auction` field on `ADO` to resolve this query.")
   chainConfigs: ChainConfigQuery!
   cw721(address: String!): CW721Ado! @deprecated(reason: "Moved to `ADO` query resolver, use `cw721` field on `ADO` to resolve this query.")
@@ -596,6 +665,14 @@ type RateInfo {
   is_additive: Boolean
   rate: Rate
   receivers: [JSON!]
+}
+
+type RateLimitingWithdrawalsAdo {
+  accountDetails: AccountDetails
+  address: String!
+  andr: AndrQuery!
+  coinAllowanceDetails: CoinAllowance
+  type: String!
 }
 
 type RatesAdo {
@@ -634,7 +711,7 @@ input SearchAttribute {
 }
 
 type Splitter {
-  locked: Boolean
+  lock: JSON
   recipients: [AddressPercent!]
 }
 
@@ -661,7 +738,7 @@ type SummaryFields {
   min_bid: Int
 }
 
-type TimelockAdo implements IBaseAdoQuery {
+type TimelockAdo {
   address: String!
   andr: AndrQuery!
   getLockedFunds(owner: String!, recipient: String!): Escrow
@@ -729,12 +806,45 @@ type TxSearchResult {
   chainId: String!
 }
 
+type UserWeightResponse {
+  total_weight: Float
+  weight: Float
+}
+
 type VaultAdo {
   address: String!
   andr: AndrQuery!
   balance(address: String!): [Coin!]
   strategyAddress(strategy: String!): AndrStrategy
   type: String!
+}
+
+type VestingAdo {
+  address: String!
+  andr: AndrQuery!
+  batch(id: Float!): VestingBatchInfo
+  batches: [VestingBatchInfo!]
+  config: VestingConfig
+  type: String!
+}
+
+type VestingBatchInfo {
+  amount: String
+  amount_available_to_claim: String
+  amount_claimed: String
+  id: Int
+  last_claimed_release_time: Int
+  lockup_end: Int
+  number_of_available_claims: String
+  release_amount: JSON
+  release_unit: Int
+}
+
+type VestingConfig {
+  denom: String
+  is_multi_batch_enabled: Boolean
+  recipient: JSON
+  unbonding_duration: JSON
 }
 
 type WasmContract implements IWasmContract {
@@ -746,4 +856,12 @@ type WasmContract implements IWasmContract {
   label: String!
   queries_expected: [String!]
   queryMsg(message: JSON!): JSON
+}
+
+type WeightedDistributionSplitterAdo {
+  address: String!
+  andr: AndrQuery!
+  config: Splitter
+  getUserWeight(user: String!): UserWeightResponse!
+  type: String!
 }


### PR DESCRIPTION
# Motivation

Implemented queries for Usecase5 ADOs(TimeLock, Weighted Distribution Splitter, Lockdrop, Vesting, Rate-Limiting Withdrawals, Merkle-Airdrop)

# Implementation
The following queries were added
TimeLock
 - GetLockedFunds
 - GetLockedFundsForRecipient
 - andr(A set of base queries common to all Andromeda ADOs)

Weighted Distribution Splitter
 - GetSplitterConfig
 - GetUserWeight
 - andr(A set of base queries common to all Andromeda ADOs)

Lockdrop
 - Config
 - State
 - UserInfo
 - WithdrawalPercentAllowed
 - andr(A set of base queries common to all Andromeda ADOs)

Vesting
 - Config
 - Batch
 - Batches
 - andr(A set of base queries common to all Andromeda ADOs)

Rate-Limiting Withdrawals
 - CoinAllowanceDetails
 - AccountDetails
 - andr(A set of base queries common to all Andromeda ADOs)

Merkle-Airdrop
 - Config
 - MerkleRoot
 - LatestStage
 - IsClaimed
 - TotalClaimed
 - andr(A set of base queries common to all Andromeda ADOs)

# Testing
- Tested all the queries using playground - Working as expected

# Notes
N/A

# Future work
N/A
