### PR TITLE
Updated base andr queries with latest changes

### DIFF
--- a/src/ado/ado.resolver.ts
+++ b/src/ado/ado.resolver.ts
@@ -44,8 +44,11 @@ export class AdoResolver {
   }
 
   @ResolveField(() => BaseAdo)
-  public async ado(@Args('address') address: string): Promise<BaseAdo> {
-    return this.adoService.getAdo<BaseAdo>(address, AdoType.Ado)
+  public async ado(
+    @Args('address') address: string,
+    @Args('version', { nullable: true }) version?: string,
+  ): Promise<BaseAdo> {
+    return this.adoService.getAdo<BaseAdo>(address, AdoType.Ado, version)
   }
 
   @ResolveField(() => AddressListAdo)

--- a/src/ado/andr-query/andr-query.resolver.ts
+++ b/src/ado/andr-query/andr-query.resolver.ts
@@ -8,36 +8,36 @@ export class AndrQueryResolver {
 
   @ResolveField(() => String)
   public async owner(@Parent() andr: AndrQuery): Promise<string> {
-    return this.andrQueryService.owner(andr.address)
+    return this.andrQueryService.owner(andr.address, andr?.contractVersion)
   }
 
   @ResolveField(() => [String])
   public async operators(@Parent() andr: AndrQuery): Promise<string[]> {
-    return this.andrQueryService.operators(andr.address)
+    return this.andrQueryService.operators(andr.address, andr?.contractVersion)
   }
 
   @ResolveField(() => Boolean)
   public async isOperator(@Parent() andr: AndrQuery, @Args('address') address: string): Promise<boolean> {
-    return this.andrQueryService.isOperator(andr.address, address)
+    return this.andrQueryService.isOperator(andr.address, address, andr?.contractVersion)
   }
 
   @ResolveField(() => String)
   public async type(@Parent() andr: AndrQuery): Promise<string> {
-    return this.andrQueryService.type(andr.address)
+    return this.andrQueryService.type(andr.address, andr?.contractVersion)
   }
 
   @ResolveField(() => Int)
   public async blockHeightUponCreation(@Parent() andr: AndrQuery): Promise<number> {
-    return this.andrQueryService.blockHeightUponCreation(andr.address)
+    return this.andrQueryService.blockHeightUponCreation(andr.address, andr?.contractVersion)
   }
 
   @ResolveField(() => String)
   public async version(@Parent() andr: AndrQuery): Promise<string> {
-    return this.andrQueryService.version(andr.address)
+    return this.andrQueryService.version(andr.address, andr?.contractVersion)
   }
 
   @ResolveField(() => String)
   public async originalPublisher(@Parent() andr: AndrQuery): Promise<string> {
-    return this.andrQueryService.originalPublisher(andr.address)
+    return this.andrQueryService.originalPublisher(andr.address, andr?.contractVersion)
   }
 }

--- a/src/ado/andr-query/andr-query.service.ts
+++ b/src/ado/andr-query/andr-query.service.ts
@@ -3,7 +3,7 @@ import { ApolloError, UserInputError } from 'apollo-server'
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino'
 import { WasmService } from 'src/wasm/wasm.service'
 import { DEFAULT_CATCH_ERR, INVALID_ADO_ERR, INVALID_QUERY_ERR } from './types'
-import { AndrQuery, AndrQuerySchema, ANDR_QUERY_OPERATOR } from './types'
+import { AndrQuery, AndrQuerySchema, AndrQuerySchemaOld, ANDR_QUERY_OPERATOR } from './types'
 
 @Injectable()
 export class AndrQueryService {
@@ -15,9 +15,10 @@ export class AndrQueryService {
     protected readonly wasmService: WasmService,
   ) {}
 
-  public async owner(address: string): Promise<string> {
+  public async owner(address: string, version?: string): Promise<string> {
+    const queryMsg = version ? AndrQuerySchema.owner : AndrQuerySchemaOld.owner
     try {
-      const queryResponse = await this.wasmService.queryContract(address, AndrQuerySchema.owner)
+      const queryResponse = await this.wasmService.queryContract(address, queryMsg)
       return queryResponse.owner
     } catch (err: any) {
       this.logger.error({ err }, DEFAULT_CATCH_ERR, address)
@@ -29,9 +30,10 @@ export class AndrQueryService {
     }
   }
 
-  public async operators(address: string): Promise<string[]> {
+  public async operators(address: string, version?: string): Promise<string[]> {
+    const queryMsg = version ? AndrQuerySchema.operators : AndrQuerySchemaOld.operators
     try {
-      const queryResponse = await this.wasmService.queryContract(address, AndrQuerySchema.operators)
+      const queryResponse = await this.wasmService.queryContract(address, queryMsg)
       return queryResponse.operators
     } catch (err: any) {
       this.logger.error({ err }, DEFAULT_CATCH_ERR, address)
@@ -43,8 +45,9 @@ export class AndrQueryService {
     }
   }
 
-  public async isOperator(address: string, operator: string): Promise<boolean> {
-    const queryMsgStr = JSON.stringify(AndrQuerySchema.is_operator).replace(ANDR_QUERY_OPERATOR, operator)
+  public async isOperator(address: string, operator: string, version?: string): Promise<boolean> {
+    const querySchema = version ? AndrQuerySchema : AndrQuerySchemaOld
+    const queryMsgStr = JSON.stringify(querySchema.is_operator).replace(ANDR_QUERY_OPERATOR, operator)
     const queryMsg = JSON.parse(queryMsgStr)
 
     try {
@@ -60,9 +63,10 @@ export class AndrQueryService {
     }
   }
 
-  public async type(address: string): Promise<string> {
+  public async type(address: string, version?: string): Promise<string> {
+    const queryMsg = version ? AndrQuerySchema.type : AndrQuerySchemaOld.type
     try {
-      const queryResponse = await this.wasmService.queryContract(address, AndrQuerySchema.type)
+      const queryResponse = await this.wasmService.queryContract(address, queryMsg)
       return queryResponse.ado_type
     } catch (err: any) {
       this.logger.error({ err }, DEFAULT_CATCH_ERR, address)
@@ -74,9 +78,13 @@ export class AndrQueryService {
     }
   }
 
-  public async blockHeightUponCreation(address: string): Promise<number> {
+  public async blockHeightUponCreation(address: string, version?: string): Promise<number> {
+    const queryMsg = version
+      ? AndrQuerySchema.block_height_upon_creation
+      : AndrQuerySchemaOld.block_height_upon_creation
+
     try {
-      const queryResponse = await this.wasmService.queryContract(address, AndrQuerySchema.block_height_upon_creation)
+      const queryResponse = await this.wasmService.queryContract(address, queryMsg)
       return queryResponse.block_height
     } catch (err: any) {
       this.logger.error({ err }, DEFAULT_CATCH_ERR, address)
@@ -88,9 +96,10 @@ export class AndrQueryService {
     }
   }
 
-  public async version(address: string): Promise<string> {
+  public async version(address: string, version?: string): Promise<string> {
+    const queryMsg = version ? AndrQuerySchema.version : AndrQuerySchemaOld.version
     try {
-      const queryResponse = await this.wasmService.queryContract(address, AndrQuerySchema.version)
+      const queryResponse = await this.wasmService.queryContract(address, queryMsg)
       return queryResponse.version
     } catch (err: any) {
       this.logger.error({ err }, DEFAULT_CATCH_ERR, address)
@@ -102,9 +111,10 @@ export class AndrQueryService {
     }
   }
 
-  public async originalPublisher(address: string): Promise<string> {
+  public async originalPublisher(address: string, version?: string): Promise<string> {
+    const queryMsg = version ? AndrQuerySchema.original_publisher : AndrQuerySchemaOld.original_publisher
     try {
-      const queryResponse = await this.wasmService.queryContract(address, AndrQuerySchema.original_publisher)
+      const queryResponse = await this.wasmService.queryContract(address, queryMsg)
       return queryResponse.original_publisher
     } catch (err: any) {
       this.logger.error({ err }, DEFAULT_CATCH_ERR, address)

--- a/src/ado/andr-query/types/andr-query.schema.ts
+++ b/src/ado/andr-query/types/andr-query.schema.ts
@@ -2,6 +2,32 @@ import { ANDR_QUERY_OPERATOR } from './andr-query.constants'
 
 export const AndrQuerySchema = {
   owner: {
+    owner: {},
+  },
+  operators: {
+    operators: {},
+  },
+  is_operator: {
+    is_operator: {
+      address: ANDR_QUERY_OPERATOR,
+    },
+  },
+  type: {
+    type: {},
+  },
+  block_height_upon_creation: {
+    block_height_upon_creation: {},
+  },
+  version: {
+    version: {},
+  },
+  original_publisher: {
+    original_publisher: {},
+  },
+}
+
+export const AndrQuerySchemaOld = {
+  owner: {
     andr_query: {
       owner: {},
     },

--- a/src/ado/andr-query/types/andr.query.ts
+++ b/src/ado/andr-query/types/andr.query.ts
@@ -46,4 +46,7 @@ export class AndrQuery implements IWasmContract {
 
   @Field(() => String)
   originalPublisher!: Promise<string>
+
+  @Field(() => String, { nullable: true })
+  contractVersion?: string
 }

--- a/src/ado/andr-query/types/index.ts
+++ b/src/ado/andr-query/types/index.ts
@@ -1,7 +1,7 @@
 export { ANDR_QUERY_OPERATOR } from './andr-query.constants'
 export { AndrQuery } from './andr.query'
 export { AdoType, AndrStrategyType, AndrOrderBy } from '../../types/ado.enums'
-export { AndrQuerySchema } from './andr-query.schema'
+export { AndrQuerySchema, AndrQuerySchemaOld } from './andr-query.schema'
 export { DEFAULT_CATCH_ERR, INVALID_ADO_ERR, INVALID_QUERY_ERR, MONGO_QUERY_ERROR } from './andr-query.constants'
 export { ANDR_QUERY, APP_QUERY, FACTORY_QUERY, CROWDFUND_QUERY } from './andr-query.constants'
 export { CW20Token_QUERY, NFT_QUERY, AUCTION_QUERY, SPLITTER_QUERY, VAULT_QUERY } from './andr-query.constants'

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -103,7 +103,7 @@ type AdoPackage {
 
 type AdoQuery {
   address_list(address: String!): AddressListAdo!
-  ado(address: String!): BaseAdo!
+  ado(address: String!, version: String): BaseAdo!
   app(address: String!): AppAdo!
   auction(address: String!): AuctionAdo!
   crowdfund(address: String!): CrowdfundAdo!
@@ -193,6 +193,7 @@ type AndrQuery implements IWasmContract {
   admin: String
   blockHeightUponCreation: Int!
   codeId: Int!
+  contractVersion: String
   creator: String!
   ibcPortId: String
   isOperator(address: String!): Boolean!


### PR DESCRIPTION
# Motivation
Andr base queries need to be updated which needs to be in line with the new version of the schema.

# Implementation
Inside AndrQuerySchema, Updated the queries by removing the andr_query key and moved all the queries to the base level.

To support the old contracts added below patch code,
Added new argument "version" to the ADO base query
example(ADO base query without version argument) => used old AndrQuerySchema queries
example(ADO base query with version argument)=> used new AndrQuerySchema queries

# Testing
Tested the andr base queries using playground - Working as expected

# Notes
NA

# Future work
The patch code needs to be removed when we entirely shift to the v2 schema.